### PR TITLE
Give the possibility to the EDC user to inject its own OpenTelemetry implementation

### DIFF
--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/DefaultServiceExtensionContext.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/DefaultServiceExtensionContext.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.boot.system;
 
+import io.opentelemetry.api.OpenTelemetry;
 import org.eclipse.dataspaceconnector.boot.util.TopologicalSort;
 import org.eclipse.dataspaceconnector.core.BaseExtension;
 import org.eclipse.dataspaceconnector.core.CoreExtension;
@@ -50,6 +51,7 @@ import java.util.stream.Stream;
  */
 public class DefaultServiceExtensionContext implements ServiceExtensionContext {
     private final Monitor monitor;
+    private final OpenTelemetry openTelemetry;
     private final TypeManager typeManager;
 
     private final Map<Class<?>, Object> services = new HashMap<>();
@@ -57,13 +59,14 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
     private List<ConfigurationExtension> configurationExtensions;
     private String connectorId;
 
-    public DefaultServiceExtensionContext(TypeManager typeManager, Monitor monitor) {
-        this(typeManager, monitor, new ServiceLocatorImpl());
+    public DefaultServiceExtensionContext(TypeManager typeManager, Monitor monitor, OpenTelemetry openTelemetry) {
+        this(typeManager, monitor, openTelemetry, new ServiceLocatorImpl());
     }
 
-    public DefaultServiceExtensionContext(TypeManager typeManager, Monitor monitor, ServiceLocator serviceLocator) {
+    public DefaultServiceExtensionContext(TypeManager typeManager, Monitor monitor, OpenTelemetry openTelemetry, ServiceLocator serviceLocator) {
         this.typeManager = typeManager;
         this.monitor = monitor;
+        this.openTelemetry = openTelemetry;
         this.serviceLocator = serviceLocator;
         // register as services
         registerService(TypeManager.class, typeManager);
@@ -78,6 +81,11 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
     @Override
     public Monitor getMonitor() {
         return monitor;
+    }
+
+    @Override
+    public OpenTelemetry getOpenTelemetry() {
+        return openTelemetry;
     }
 
     @Override

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.dataspaceconnector.boot.system;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import org.eclipse.dataspaceconnector.core.monitor.ConsoleMonitor;
 import org.eclipse.dataspaceconnector.core.security.NullVaultExtension;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -101,5 +103,15 @@ public class ExtensionLoader {
         }
 
         return availableMonitors.get(0).getMonitor();
+    }
+
+    public static @NotNull OpenTelemetry loadOpenTelemetry() {
+        var loader = ServiceLoader.load(OpenTelemetry.class);
+        return loadOpenTelemetry(loader.stream().map(ServiceLoader.Provider::get).collect(Collectors.toList()));
+    }
+
+    static @NotNull OpenTelemetry loadOpenTelemetry(List<OpenTelemetry> availableOpenTelemetries) {
+
+        return availableOpenTelemetries.isEmpty() ? GlobalOpenTelemetry.get() : availableOpenTelemetries.get(0);
     }
 }

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/runtime/BaseRuntime.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/runtime/BaseRuntime.java
@@ -1,6 +1,7 @@
 package org.eclipse.dataspaceconnector.boot.system.runtime;
 
 
+import io.opentelemetry.api.OpenTelemetry;
 import org.eclipse.dataspaceconnector.boot.monitor.MonitorProvider;
 import org.eclipse.dataspaceconnector.boot.system.DefaultServiceExtensionContext;
 import org.eclipse.dataspaceconnector.boot.system.ExtensionLoader;
@@ -38,6 +39,7 @@ public class BaseRuntime {
 
     private final AtomicReference<HealthCheckResult> startupStatus = new AtomicReference<>(HealthCheckResult.failed("Startup not complete"));
     private Monitor monitor;
+    private OpenTelemetry openTelemetry;
 
     public static void main(String[] args) {
         BaseRuntime runtime = new BaseRuntime();
@@ -54,9 +56,11 @@ public class BaseRuntime {
     protected void boot() {
         var typeManager = createTypeManager();
         monitor = createMonitor();
+        openTelemetry = ExtensionLoader.loadOpenTelemetry();
+
         MonitorProvider.setInstance(monitor);
 
-        var context = createContext(typeManager, monitor);
+        var context = createContext(typeManager, monitor, openTelemetry);
         initializeContext(context);
 
 
@@ -134,8 +138,8 @@ public class BaseRuntime {
      * @return a {@code ServiceExtensionContext}
      */
     @NotNull
-    protected ServiceExtensionContext createContext(TypeManager typeManager, Monitor monitor) {
-        return new DefaultServiceExtensionContext(typeManager, monitor);
+    protected ServiceExtensionContext createContext(TypeManager typeManager, Monitor monitor, OpenTelemetry openTelemetry) {
+        return new DefaultServiceExtensionContext(typeManager, monitor, openTelemetry);
     }
 
     /**

--- a/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/DefaultServiceExtensionContextTest.java
+++ b/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/DefaultServiceExtensionContextTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.boot.system;
 
+import io.opentelemetry.api.OpenTelemetry;
 import org.eclipse.dataspaceconnector.boot.util.CyclicDependencyException;
 import org.eclipse.dataspaceconnector.core.BaseExtension;
 import org.eclipse.dataspaceconnector.spi.EdcException;
@@ -53,8 +54,9 @@ class DefaultServiceExtensionContextTest {
     void setUp() {
         TypeManager typeManager = new TypeManager();
         Monitor monitor = mock(Monitor.class);
+        OpenTelemetry openTelemetry = mock(OpenTelemetry.class);
         serviceLocatorMock = mock(ServiceLocator.class);
-        context = new DefaultServiceExtensionContext(typeManager, monitor, serviceLocatorMock);
+        context = new DefaultServiceExtensionContext(typeManager, monitor, openTelemetry, serviceLocatorMock);
     }
 
     @Test

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.dataspaceconnector.contract;
 
+import io.opentelemetry.api.OpenTelemetry;
 import org.eclipse.dataspaceconnector.contract.agent.ParticipantAgentServiceImpl;
 import org.eclipse.dataspaceconnector.contract.negotiation.ConsumerContractNegotiationManagerImpl;
 import org.eclipse.dataspaceconnector.contract.negotiation.ProviderContractNegotiationManagerImpl;
@@ -50,6 +51,7 @@ public class ContractServiceExtension implements ServiceExtension {
 
     private static final long DEFAULT_ITERATION_WAIT = 5000; // millis
     private Monitor monitor;
+    private OpenTelemetry openTelemetry;
     private ServiceExtensionContext context;
     private ConsumerContractNegotiationManagerImpl consumerNegotiationManager;
     private ProviderContractNegotiationManagerImpl providerNegotiationManager;
@@ -68,6 +70,7 @@ public class ContractServiceExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         monitor = context.getMonitor();
+        openTelemetry = context.getOpenTelemetry();
         this.context = context;
 
         registerTypes(context);
@@ -129,6 +132,7 @@ public class ContractServiceExtension implements ServiceExtension {
                 .waitStrategy(waitStrategy)
                 .dispatcherRegistry(dispatcherRegistry)
                 .monitor(monitor)
+                .openTelemetry(openTelemetry)
                 .validationService(validationService)
                 .build();
 

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -59,8 +59,7 @@ import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiati
  */
 public class ProviderContractNegotiationManagerImpl extends ContractNegotiationObservable implements ProviderContractNegotiationManager {
 
-    // TODO: Follow https://opentelemetry.io/docs/instrumentation/java/manual_instrumentation/
-    private final OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
+    private OpenTelemetry openTelemetry;
     private static ContractNegotiationTraceContextMapper traceContextMapper = new ContractNegotiationTraceContextMapper();
 
     private final AtomicBoolean active = new AtomicBoolean();
@@ -489,6 +488,11 @@ public class ProviderContractNegotiationManagerImpl extends ContractNegotiationO
 
         public Builder monitor(Monitor monitor) {
             manager.monitor = monitor;
+            return this;
+        }
+
+        public Builder openTelemetry(OpenTelemetry openTelemetry) {
+            manager.openTelemetry = openTelemetry;
             return this;
         }
 

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationIntegrationTest.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.dataspaceconnector.contract.negotiation;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import org.eclipse.dataspaceconnector.contract.common.ContractId;
 import org.eclipse.dataspaceconnector.negotiation.store.memory.InMemoryContractNegotiationStore;
 import org.eclipse.dataspaceconnector.policy.model.Action;
@@ -79,6 +80,7 @@ public abstract class AbstractContractNegotiationIntegrationTest {
         providerManager = ProviderContractNegotiationManagerImpl.Builder.newInstance()
                 .dispatcherRegistry(new FakeProviderDispatcherRegistry())
                 .monitor(monitor)
+                .openTelemetry(GlobalOpenTelemetry.get())
                 .validationService(validationService)
                 .waitStrategy(() -> 1000)
                 .build();

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.dataspaceconnector.contract.negotiation;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.response.NegotiationResult;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
@@ -92,6 +93,7 @@ class ProviderContractNegotiationManagerImplTest {
                 .validationService(validationService)
                 .dispatcherRegistry(dispatcherRegistry)
                 .monitor(monitor)
+                .openTelemetry(GlobalOpenTelemetry.get())
                 .build();
 
         //TODO hand over store in start method, but run method should not be executed

--- a/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/EdcExtension.java
+++ b/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/EdcExtension.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.dataspaceconnector.junit.launcher;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import okhttp3.Interceptor;
 import org.eclipse.dataspaceconnector.boot.monitor.MonitorProvider;
 import org.eclipse.dataspaceconnector.boot.system.DefaultServiceExtensionContext;
@@ -52,6 +54,7 @@ public class EdcExtension implements BeforeTestExecutionCallback, AfterTestExecu
     private List<ServiceExtension> runningServiceExtensions;
     private DefaultServiceExtensionContext context;
     private Monitor monitor;
+    private OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
 
     /**
      * Registers a mock service with the runtime.
@@ -81,7 +84,7 @@ public class EdcExtension implements BeforeTestExecutionCallback, AfterTestExecu
 
         MonitorProvider.setInstance(monitor);
 
-        context = new DefaultServiceExtensionContext(typeManager, monitor, new MultiSourceServiceLocator());
+        context = new DefaultServiceExtensionContext(typeManager, monitor, openTelemetry, new MultiSourceServiceLocator());
         context.initialize();
 
         serviceMocks.forEach((key, value) -> context.registerService(cast(key), value));

--- a/launchers/registration-service-app/src/main/java/org/eclipse/dataspaceconnector/did/RegistrationServiceRuntime.java
+++ b/launchers/registration-service-app/src/main/java/org/eclipse/dataspaceconnector/did/RegistrationServiceRuntime.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import static org.eclipse.dataspaceconnector.boot.system.ExtensionLoader.bootServiceExtensions;
 import static org.eclipse.dataspaceconnector.boot.system.ExtensionLoader.loadMonitor;
+import static org.eclipse.dataspaceconnector.boot.system.ExtensionLoader.loadOpenTelemetry;
 import static org.eclipse.dataspaceconnector.boot.system.ExtensionLoader.loadVault;
 
 public class RegistrationServiceRuntime {
@@ -34,8 +35,9 @@ public class RegistrationServiceRuntime {
     public static void main(String[] args) {
         TypeManager typeManager = new TypeManager();
         var monitor = loadMonitor();
+        var openTelemetry = loadOpenTelemetry();
         MonitorProvider.setInstance(monitor);
-        DefaultServiceExtensionContext context = new DefaultServiceExtensionContext(typeManager, monitor);
+        DefaultServiceExtensionContext context = new DefaultServiceExtensionContext(typeManager, monitor, openTelemetry);
         context.initialize();
 
         try {

--- a/samples/other/commandline/consumer-runtime/src/main/java/org/eclipse/dataspaceconnector/consumer/runtime/EdcConnectorConsumerRuntime.java
+++ b/samples/other/commandline/consumer-runtime/src/main/java/org/eclipse/dataspaceconnector/consumer/runtime/EdcConnectorConsumerRuntime.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.dataspaceconnector.consumer.runtime;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import org.eclipse.dataspaceconnector.boot.monitor.MonitorProvider;
 import org.eclipse.dataspaceconnector.boot.system.DefaultServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -31,6 +33,7 @@ import static org.eclipse.dataspaceconnector.boot.system.ExtensionLoader.loadVau
 
 public class EdcConnectorConsumerRuntime {
     private Monitor monitor;
+    private OpenTelemetry openTelemetry;
     private TypeManager typeManager;
     private List<ServiceExtension> serviceExtensions;
     private DefaultServiceExtensionContext context;
@@ -40,8 +43,8 @@ public class EdcConnectorConsumerRuntime {
 
     public void start() {
         MonitorProvider.setInstance(monitor);
-
-        context = new DefaultServiceExtensionContext(typeManager, monitor);
+        openTelemetry = GlobalOpenTelemetry.get();
+        context = new DefaultServiceExtensionContext(typeManager, monitor, openTelemetry);
         context.initialize();
 
         try {

--- a/samples/other/custom-runtime/src/main/java/org/eclipse/dataspaceconnector/demo/runtime/CustomRuntime.java
+++ b/samples/other/custom-runtime/src/main/java/org/eclipse/dataspaceconnector/demo/runtime/CustomRuntime.java
@@ -1,5 +1,6 @@
 package org.eclipse.dataspaceconnector.demo.runtime;
 
+import io.opentelemetry.api.OpenTelemetry;
 import org.eclipse.dataspaceconnector.boot.system.DefaultServiceExtensionContext;
 import org.eclipse.dataspaceconnector.boot.system.runtime.BaseRuntime;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -26,9 +27,9 @@ public class CustomRuntime extends BaseRuntime {
     }
 
     @Override
-    protected @NotNull ServiceExtensionContext createContext(TypeManager typeManager, Monitor monitor) {
+    protected @NotNull ServiceExtensionContext createContext(TypeManager typeManager, Monitor monitor, OpenTelemetry openTelemetry) {
         //override the default service extension context with a super customized one
-        return new SuperCustomExtensionContext(typeManager, monitor);
+        return new SuperCustomExtensionContext(typeManager, monitor, openTelemetry);
     }
 
     @Override
@@ -40,8 +41,8 @@ public class CustomRuntime extends BaseRuntime {
     }
 
     private static class SuperCustomExtensionContext extends DefaultServiceExtensionContext {
-        public SuperCustomExtensionContext(TypeManager typeManager, Monitor monitor) {
-            super(typeManager, monitor);
+        public SuperCustomExtensionContext(TypeManager typeManager, Monitor monitor, OpenTelemetry openTelemetry) {
+            super(typeManager, monitor, openTelemetry);
         }
     }
 }

--- a/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiation.java
+++ b/spi/contract-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/contract/negotiation/ContractNegotiation.java
@@ -58,7 +58,7 @@ public class ContractNegotiation {
     private String counterPartyId;
     private String counterPartyAddress;
     private String protocol;
-    private Map<String, String> traceContext;
+    private Map<String, String> traceContext = new HashMap<>();
     private Type type = Type.CONSUMER;
     private int state = UNSAVED.code();
     private int stateCount;

--- a/spi/core-spi/build.gradle.kts
+++ b/spi/core-spi/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}")
     api("com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}")
     api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}")
+    api("io.opentelemetry:opentelemetry-api:1.10.0")
+    api("io.opentelemetry:opentelemetry-extension-annotations:1.10.0")
 
     testImplementation(testFixtures(project(":common:util")))
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ServiceExtensionContext.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ServiceExtensionContext.java
@@ -14,13 +14,13 @@
 
 package org.eclipse.dataspaceconnector.spi.system;
 
+import io.opentelemetry.api.OpenTelemetry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Context provided to extensions when they are initialized.
@@ -37,6 +37,12 @@ public interface ServiceExtensionContext extends SettingResolver {
      * Returns the system monitor.
      */
     Monitor getMonitor();
+
+    /**
+     * Returns the OpenTelemetry.
+     * This is the entrypoint to telemetry functionality for tracing, metrics and baggage.
+     */
+    OpenTelemetry getOpenTelemetry();
 
     /**
      * Returns the type manager.


### PR DESCRIPTION
If a user wants to use OpenTelemetry, the recommended way is to use the java agent.