### PR TITLE
Feature/6 Let the user inject its own OpenTelemetry implementation.

### DIFF
--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
@@ -103,9 +103,8 @@ public class ExtensionLoader {
     }
 
     static @NotNull OpenTelemetry loadOpenTelemetry(List<OpenTelemetry> openTelemetries) {
-        if (openTelemetries.size() > 1) throw new IllegalStateException(
-                String.format("Found %s OpenTelemetry implementations. " +
-                        "Please provide only one OpenTelemetry service provider.", openTelemetries.size()));
+        if (openTelemetries.size() > 1)
+            throw new IllegalStateException(String.format("Found %s OpenTelemetry implementations. Please provide only one OpenTelemetry service provider.", openTelemetries.size()));
         return openTelemetries.isEmpty() ? GlobalOpenTelemetry.get() : openTelemetries.get(0);
     }
 

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
@@ -93,16 +93,12 @@ public class ExtensionLoader {
     }
 
     public static @NotNull Telemetry loadTelemetry() {
-        return new Telemetry(loadOpenTelemetry());
-    }
-
-    public static @NotNull OpenTelemetry loadOpenTelemetry() {
         var loader = ServiceLoader.load(OpenTelemetry.class);
         var openTelemetries = loader.stream().map(ServiceLoader.Provider::get).collect(Collectors.toList());
-        return loadOpenTelemetry(openTelemetries);
+        return new Telemetry(loadOpenTelemetry(openTelemetries));
     }
 
-    static @NotNull OpenTelemetry loadOpenTelemetry(List<OpenTelemetry> openTelemetries) {
+    public static @NotNull OpenTelemetry loadOpenTelemetry(List<OpenTelemetry> openTelemetries) {
         if (openTelemetries.size() > 1)
             throw new IllegalStateException(String.format("Found %s OpenTelemetry implementations. Please provide only one OpenTelemetry service provider.", openTelemetries.size()));
         return openTelemetries.isEmpty() ? GlobalOpenTelemetry.get() : openTelemetries.get(0);

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.boot.system;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import org.eclipse.dataspaceconnector.core.monitor.ConsoleMonitor;
 import org.eclipse.dataspaceconnector.core.security.NullVaultExtension;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -92,8 +93,13 @@ public class ExtensionLoader {
     }
 
     public static @NotNull Telemetry loadTelemetry() {
-        // TODO: enable overriding telemetry through an extension
-        return new Telemetry(GlobalOpenTelemetry.get());
+        return new Telemetry(loadOpenTelemetry());
+    }
+
+    public static @NotNull OpenTelemetry loadOpenTelemetry() {
+        var loader = ServiceLoader.load(OpenTelemetry.class);
+        var openTelemetries = loader.stream().map(ServiceLoader.Provider::get).collect(Collectors.toList());
+        return openTelemetries.isEmpty() ? GlobalOpenTelemetry.get() : openTelemetries.get(0);
     }
 
     static @NotNull Monitor loadMonitor(List<MonitorExtension> availableMonitors) {

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
@@ -99,6 +99,11 @@ public class ExtensionLoader {
     public static @NotNull OpenTelemetry loadOpenTelemetry() {
         var loader = ServiceLoader.load(OpenTelemetry.class);
         var openTelemetries = loader.stream().map(ServiceLoader.Provider::get).collect(Collectors.toList());
+        return loadOpenTelemetry(openTelemetries);
+    }
+
+    static @NotNull OpenTelemetry loadOpenTelemetry(List<OpenTelemetry> openTelemetries) {
+        if (openTelemetries.size() > 1) throw new IllegalStateException("Please provide only one OpenTelemetry service provider.");
         return openTelemetries.isEmpty() ? GlobalOpenTelemetry.get() : openTelemetries.get(0);
     }
 

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
@@ -99,8 +99,9 @@ public class ExtensionLoader {
     }
 
     public static @NotNull OpenTelemetry loadOpenTelemetry(List<OpenTelemetry> openTelemetries) {
-        if (openTelemetries.size() > 1)
+        if (openTelemetries.size() > 1) {
             throw new IllegalStateException(String.format("Found %s OpenTelemetry implementations. Please provide only one OpenTelemetry service provider.", openTelemetries.size()));
+        }
         return openTelemetries.isEmpty() ? GlobalOpenTelemetry.get() : openTelemetries.get(0);
     }
 

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
@@ -98,7 +98,7 @@ public class ExtensionLoader {
         return new Telemetry(loadOpenTelemetry(openTelemetries));
     }
 
-    public static @NotNull OpenTelemetry loadOpenTelemetry(List<OpenTelemetry> openTelemetries) {
+    protected static @NotNull OpenTelemetry loadOpenTelemetry(List<OpenTelemetry> openTelemetries) {
         if (openTelemetries.size() > 1) {
             throw new IllegalStateException(String.format("Found %s OpenTelemetry implementations. Please provide only one OpenTelemetry service provider.", openTelemetries.size()));
         }

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoader.java
@@ -103,7 +103,9 @@ public class ExtensionLoader {
     }
 
     static @NotNull OpenTelemetry loadOpenTelemetry(List<OpenTelemetry> openTelemetries) {
-        if (openTelemetries.size() > 1) throw new IllegalStateException("Please provide only one OpenTelemetry service provider.");
+        if (openTelemetries.size() > 1) throw new IllegalStateException(
+                String.format("Found %s OpenTelemetry implementations. " +
+                        "Please provide only one OpenTelemetry service provider.", openTelemetries.size()));
         return openTelemetries.isEmpty() ? GlobalOpenTelemetry.get() : openTelemetries.get(0);
     }
 

--- a/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoaderTest.java
+++ b/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoaderTest.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.dataspaceconnector.boot.system;
 
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.TracerProvider;
+import io.opentelemetry.context.propagation.ContextPropagators;
 import org.eclipse.dataspaceconnector.core.monitor.ConsoleMonitor;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.monitor.MultiplexingMonitor;
@@ -26,8 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -66,6 +68,37 @@ class ExtensionLoaderTest {
         var monitor = ExtensionLoader.loadMonitor(new ArrayList<>());
 
         assertTrue(monitor instanceof ConsoleMonitor);
+    }
+
+    @Test
+    void loadOpenTelemetry_whenNoOpenTelemetryExtension() {
+        var openTelemetry = ExtensionLoader.loadOpenTelemetry(new ArrayList<>());
+    }
+
+    @Test
+    void loadOpenTelemetry_whenSingleOpenTelemetryExtension() {
+        var openTelemetries = new ArrayList<>();
+        class CustomOpenTelemetry implements OpenTelemetry {
+
+            @Override
+            public TracerProvider getTracerProvider() {
+                return null;
+            }
+
+            @Override
+            public ContextPropagators getPropagators() {
+                return null;
+            }
+        }
+        openTelemetries.add(new CustomOpenTelemetry());
+
+        var openTelemetry = ExtensionLoader.loadOpenTelemetry();
+        assertTrue(openTelemetry instanceof CustomOpenTelemetry);
+    }
+
+    @Test
+    void loadOpenTelemetry_whenSeveralOpenTelemetryExtension() {
+        //assertThrows()
     }
 
     @Test
@@ -115,4 +148,7 @@ class ExtensionLoaderTest {
         verify(contextMock, atLeastOnce()).getMonitor();
         verify(contextMock).loadSingletonExtension(VaultExtension.class, false);
     }
+
+    @Test
+    void loadOpenTelemetry()
 }

--- a/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoaderTest.java
+++ b/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoaderTest.java
@@ -159,5 +159,4 @@ class ExtensionLoaderTest {
         verify(contextMock, atLeastOnce()).getMonitor();
         verify(contextMock).loadSingletonExtension(VaultExtension.class, false);
     }
-
 }

--- a/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoaderTest.java
+++ b/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoaderTest.java
@@ -103,7 +103,7 @@ class ExtensionLoaderTest {
     void loadOpenTelemetry_whenSingleOpenTelemetry() {
         List<OpenTelemetry> openTelemetries = Arrays.asList(new CustomOpenTelemetry());
         var openTelemetry = ExtensionLoader.loadOpenTelemetry(openTelemetries);
-        assertThat(openTelemetry).isInstanceOf(CustomOpenTelemetry.class)
+        assertThat(openTelemetry).isInstanceOf(CustomOpenTelemetry.class);
     }
 
     @Test

--- a/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoaderTest.java
+++ b/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoaderTest.java
@@ -14,9 +14,11 @@
 
 package org.eclipse.dataspaceconnector.boot.system;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
+import net.bytebuddy.agent.builder.AgentBuilder;
 import org.eclipse.dataspaceconnector.core.monitor.ConsoleMonitor;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.monitor.MultiplexingMonitor;
@@ -89,19 +91,21 @@ class ExtensionLoaderTest {
     }
 
     @Test
-    void loadOpenTelemetry_whenNoOpenTelemetryExtension() {
+    void loadOpenTelemetry_whenNoOpenTelemetry() {
+        GlobalOpenTelemetry.set(new CustomOpenTelemetry());
         var openTelemetry = ExtensionLoader.loadOpenTelemetry(new ArrayList<>());
+        assertEquals(openTelemetry, GlobalOpenTelemetry.get());
     }
 
     @Test
-    void loadOpenTelemetry_whenSingleOpenTelemetryExtension() {
+    void loadOpenTelemetry_whenSingleOpenTelemetry() {
         List<OpenTelemetry> openTelemetries = Arrays.asList(new CustomOpenTelemetry());
         var openTelemetry = ExtensionLoader.loadOpenTelemetry(openTelemetries);
         assertTrue(openTelemetry instanceof CustomOpenTelemetry);
     }
 
     @Test
-    void loadOpenTelemetry_whenSeveralOpenTelemetryExtension() {
+    void loadOpenTelemetry_whenSeveralOpenTelemetry() {
         List<OpenTelemetry> openTelemetries = new ArrayList<>(Arrays.asList(new CustomOpenTelemetry(), new CustomOpenTelemetry()));
         Exception thrown = assertThrows(IllegalStateException.class, () -> ExtensionLoader.loadOpenTelemetry(openTelemetries));
         assertEquals(thrown.getMessage(), "Please provide only one OpenTelemetry service provider.");

--- a/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoaderTest.java
+++ b/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoaderTest.java
@@ -32,7 +32,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;

--- a/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoaderTest.java
+++ b/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoaderTest.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -102,7 +103,7 @@ class ExtensionLoaderTest {
     void loadOpenTelemetry_whenSingleOpenTelemetry() {
         List<OpenTelemetry> openTelemetries = Arrays.asList(new CustomOpenTelemetry());
         var openTelemetry = ExtensionLoader.loadOpenTelemetry(openTelemetries);
-        assertTrue(openTelemetry instanceof CustomOpenTelemetry);
+        assertThat(openTelemetry).isInstanceOf(CustomOpenTelemetry.class)
     }
 
     @Test

--- a/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoaderTest.java
+++ b/core/boot/src/test/java/org/eclipse/dataspaceconnector/boot/system/ExtensionLoaderTest.java
@@ -18,7 +18,6 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import net.bytebuddy.agent.builder.AgentBuilder;
 import org.eclipse.dataspaceconnector.core.monitor.ConsoleMonitor;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.monitor.MultiplexingMonitor;
@@ -108,7 +107,7 @@ class ExtensionLoaderTest {
     void loadOpenTelemetry_whenSeveralOpenTelemetry() {
         List<OpenTelemetry> openTelemetries = new ArrayList<>(Arrays.asList(new CustomOpenTelemetry(), new CustomOpenTelemetry()));
         Exception thrown = assertThrows(IllegalStateException.class, () -> ExtensionLoader.loadOpenTelemetry(openTelemetries));
-        assertEquals(thrown.getMessage(), "Please provide only one OpenTelemetry service provider.");
+        assertEquals(thrown.getMessage(), "Found 2 OpenTelemetry implementations. Please provide only one OpenTelemetry service provider.");
     }
 
     @Test

--- a/samples/04.3-open-telemetry/README.md
+++ b/samples/04.3-open-telemetry/README.md
@@ -55,3 +55,14 @@ Other monitoring backends can be plugged in easily with OpenTelemetry. For insta
       - 9191:8181
     entrypoint: java -javaagent:/samples/04.3-open-telemetry/applicationinsights-agent-3.2.5.jar -jar /samples/04.0-file-transfer/consumer/build/libs/consumer.jar
 ```
+
+## Provide your own OpenTelemetry implementation
+
+In order to provide your own OpenTelemetry implementation, you have to "deploy an OpenTelemetry service provider on the class path":
+
+- Create a module containing your OpenTelemetry implementation.
+- Add a file in the resource directory META-INF/services. The file should be called `io.opentelemetry.api.OpenTelemetry`.
+- Add to the file the fully qualified name of your custom OpenTelemetry implementation class.
+
+EDC uses a [ServiceLoader](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html) to load an implementation of OpenTelemetry. If it finds an OpenTelemetry service provider on the class path it will use it, otherwise it will use the registered global OpenTelemetry.
+You can look at the section `Deploying service providers on the class path` of the [ServiceLoader documentation](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html) to have more information about service providers.


### PR DESCRIPTION
Let the user provide its own OpenTelemetry implementation.

If an OpenTelemetry implementation is found in class path, it will be used. Otherwise the registered Global OpenTelemetry implementation will be used.

Note that if the opentelemetry agent is used, the global OpenTelemetry implementation can be customized with env vars and JVM args. If the agent is not provided, the registered Global OpenTelemetry implementation will be a dummy one doing nothing.

The recommended way to use OpenTelemetry is to:
- Provide the agent with customization via env var/JVM args.
- Do not provide a custom OpenTelemetry implementation.

This possibility to inject an OpenTelemetry implementation might be useful if a user cannot use the java agent for example.

More details about how EDC loads the custom OpenTelemetry implementation:
The [ServiceLoader](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html) will look for a "service provider" on the class path.
The service provider can be provided by adding a file in the resources/META-INF/services folder. More details can be found in the section "Deploying service providers on the class path" of the  [ServiceLoader documentation](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html).