### PR TITLE
Feature/6 Added default telemetry to TransferProcessManager and ContractNegotiationManagers.

### DIFF
--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -73,7 +73,7 @@ public class ConsumerContractNegotiationManagerImpl extends ContractNegotiationO
     private int batchSize = 5;
     private NegotiationWaitStrategy waitStrategy = () -> 5000L;  // default wait five seconds
     private Monitor monitor;
-    private Telemetry telemetry = new Telemetry(GlobalOpenTelemetry.get());
+    private Telemetry telemetry;
     private ExecutorService executor;
 
     private RemoteMessageDispatcherRegistry dispatcherRegistry;
@@ -513,7 +513,7 @@ public class ConsumerContractNegotiationManagerImpl extends ContractNegotiationO
         }
 
         public static Builder newInstance() {
-            return new Builder();
+            return new Builder().telemetry(new Telemetry(GlobalOpenTelemetry.get()));
         }
 
         public Builder validationService(ContractValidationService validationService) {

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -14,6 +14,7 @@
  */
 package org.eclipse.dataspaceconnector.contract.negotiation;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.dataspaceconnector.contract.common.ContractId;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ConsumerContractNegotiationManager;
@@ -72,7 +73,7 @@ public class ConsumerContractNegotiationManagerImpl extends ContractNegotiationO
     private int batchSize = 5;
     private NegotiationWaitStrategy waitStrategy = () -> 5000L;  // default wait five seconds
     private Monitor monitor;
-    private Telemetry telemetry;
+    private Telemetry telemetry = new Telemetry(GlobalOpenTelemetry.get());
     private ExecutorService executor;
 
     private RemoteMessageDispatcherRegistry dispatcherRegistry;

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -67,7 +67,7 @@ public class ProviderContractNegotiationManagerImpl extends ContractNegotiationO
     private ContractValidationService validationService;
     private RemoteMessageDispatcherRegistry dispatcherRegistry;
     private Monitor monitor;
-    private Telemetry telemetry = new Telemetry(GlobalOpenTelemetry.get());
+    private Telemetry telemetry;
     private ExecutorService executor;
 
     private ProviderContractNegotiationManagerImpl() { }
@@ -471,7 +471,7 @@ public class ProviderContractNegotiationManagerImpl extends ContractNegotiationO
         }
 
         public static Builder newInstance() {
-            return new Builder();
+            return new Builder().telemetry(new Telemetry(GlobalOpenTelemetry.get()));
         }
 
         public Builder validationService(ContractValidationService validationService) {

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -14,6 +14,7 @@
  */
 package org.eclipse.dataspaceconnector.contract.negotiation;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.dataspaceconnector.contract.common.ContractId;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ContractNegotiationObservable;
@@ -66,7 +67,7 @@ public class ProviderContractNegotiationManagerImpl extends ContractNegotiationO
     private ContractValidationService validationService;
     private RemoteMessageDispatcherRegistry dispatcherRegistry;
     private Monitor monitor;
-    private Telemetry telemetry;
+    private Telemetry telemetry = new Telemetry(GlobalOpenTelemetry.get());
     private ExecutorService executor;
 
     private ProviderContractNegotiationManagerImpl() { }

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationIntegrationTest.java
@@ -76,16 +76,12 @@ public abstract class AbstractContractNegotiationIntegrationTest {
         // Create a monitor that logs to the console
         Monitor monitor = new FakeConsoleMonitor();
 
-        // Create telemetry mock
-        Telemetry telemetry = new Telemetry(OpenTelemetry.noop());
-
         // Create the provider contract negotiation manager
         providerManager = ProviderContractNegotiationManagerImpl.Builder.newInstance()
                 .dispatcherRegistry(new FakeProviderDispatcherRegistry())
                 .monitor(monitor)
                 .validationService(validationService)
                 .waitStrategy(() -> 1000)
-                .telemetry(telemetry)
                 .build();
         providerStore = new InMemoryContractNegotiationStore();
 
@@ -95,7 +91,6 @@ public abstract class AbstractContractNegotiationIntegrationTest {
                 .monitor(monitor)
                 .validationService(validationService)
                 .waitStrategy(() -> 1000)
-                .telemetry(telemetry)
                 .build();
         consumerStore = new InMemoryContractNegotiationStore();
         

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -59,13 +59,11 @@ class ConsumerContractNegotiationManagerImplTest {
     void setUp() throws Exception {
 
         Monitor monitor = mock(Monitor.class);
-        Telemetry telemetry = new Telemetry(OpenTelemetry.noop());
 
         negotiationManager = ConsumerContractNegotiationManagerImpl.Builder.newInstance()
                 .validationService(validationService)
                 .dispatcherRegistry(dispatcherRegistry)
                 .monitor(monitor)
-                .telemetry(telemetry)
                 .build();
 
         //TODO hand over store in start method, but run method should not be executed

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -90,14 +90,10 @@ class ProviderContractNegotiationManagerImplTest {
         // Create monitor mock
         Monitor monitor = mock(Monitor.class);
 
-        // Create telemetry mock
-        Telemetry telemetry = new Telemetry(OpenTelemetry.noop());
-
         negotiationManager = ProviderContractNegotiationManagerImpl.Builder.newInstance()
                 .validationService(validationService)
                 .dispatcherRegistry(dispatcherRegistry)
                 .monitor(monitor)
-                .telemetry(telemetry)
                 .build();
 
         //TODO hand over store in start method, but run method should not be executed

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -99,7 +99,7 @@ public class TransferProcessManagerImpl extends TransferProcessObservable implem
     private RemoteMessageDispatcherRegistry dispatcherRegistry;
     private DataFlowManager dataFlowManager;
     private Monitor monitor;
-    private Telemetry telemetry = new Telemetry(GlobalOpenTelemetry.get());
+    private Telemetry telemetry;
     private ExecutorService executor;
     private StatusCheckerRegistry statusCheckerRegistry;
     private Vault vault;
@@ -627,7 +627,7 @@ public class TransferProcessManagerImpl extends TransferProcessObservable implem
         }
 
         public static Builder newInstance() {
-            return new Builder();
+            return new Builder().telemetry(new Telemetry(GlobalOpenTelemetry.get()));
         }
 
         public Builder batchSize(int size) {

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.transfer.core.transfer;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.dataspaceconnector.spi.command.Command;
 import org.eclipse.dataspaceconnector.spi.command.CommandQueue;
@@ -98,7 +99,7 @@ public class TransferProcessManagerImpl extends TransferProcessObservable implem
     private RemoteMessageDispatcherRegistry dispatcherRegistry;
     private DataFlowManager dataFlowManager;
     private Monitor monitor;
-    private Telemetry telemetry;
+    private Telemetry telemetry = new Telemetry(GlobalOpenTelemetry.get());
     private ExecutorService executor;
     private StatusCheckerRegistry statusCheckerRegistry;
     private Vault vault;

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
@@ -64,7 +64,6 @@ class TransferProcessManagerImplIntegrationTest {
                 .dispatcherRegistry(mock(RemoteMessageDispatcherRegistry.class))
                 .manifestGenerator(manifestGenerator)
                 .monitor(mock(Monitor.class))
-                .telemetry(new Telemetry(OpenTelemetry.noop()))
                 .commandQueue(mock(CommandQueue.class))
                 .commandRunner(mock(CommandRunner.class))
                 .typeManager(new TypeManager())

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -16,7 +16,6 @@ package org.eclipse.dataspaceconnector.transfer.core.transfer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.opentelemetry.api.OpenTelemetry;
 import org.eclipse.dataspaceconnector.core.base.ExponentialWaitStrategy;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.command.CommandQueue;
@@ -24,7 +23,6 @@ import org.eclipse.dataspaceconnector.spi.command.CommandRunner;
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.response.ResponseFailure;
-import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowManager;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ProvisionManager;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceManifestGenerator;
@@ -106,7 +104,6 @@ class TransferProcessManagerImplTest {
                 .dispatcherRegistry(dispatcherRegistry)
                 .manifestGenerator(manifestGenerator)
                 .monitor(mock(Monitor.class))
-                .telemetry(new Telemetry(OpenTelemetry.noop()))
                 .commandQueue(mock(CommandQueue.class))
                 .commandRunner(mock(CommandRunner.class))
                 .typeManager(new TypeManager())


### PR DESCRIPTION
Added default telemetry for
- TransferProcessManagerImpl
- ConsumerContractNegotiationManagerImpl
- ProviderContractNegotiationManagerImpl

This is done to simplify the tests where you need to create a new telemetry object.