### PR TITLE
Feature/646/98 jacoco in ci

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Gradle Test Core
         env:
           INTEGRATION_TEST: false
+          JACOCO: true
         # checkstyle would also run as part of the `check` task
         run: ./gradlew clean check jacocoTestReport -x checkstyleMain -x checkstyleTest
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,10 @@ allprojects {
     apply(plugin = "maven-publish")
     apply(plugin = "checkstyle")
     apply(plugin = "java")
-    apply(plugin = "jacoco")
+
+    if (System.getenv("JACOCO") == "true") {
+        apply(plugin = "jacoco")
+    }
 
     checkstyle {
         toolVersion = "9.0"
@@ -174,9 +177,11 @@ allprojects {
     }
 
     // Generate XML reports for Codecov
-    tasks.jacocoTestReport {
-        reports {
-            xml.required.set(true)
+    if (System.getenv("JACOCO") == "true") {
+        tasks.jacocoTestReport {
+            reports {
+                xml.required.set(true)
+            }
         }
     }
 }


### PR DESCRIPTION
Run Jacoco only in CI.

I did a test run in CI disabling Jacoco, and build time is reduced from 11.5 min to 7.5 min. We won't disable Jacoco in CI of course, but this illustrates the gain we can get in Dev.

Run with Jacoco: https://github.com/agera-edc/DataSpaceConnector/actions/runs/1884394652
Run without Jacoco: https://github.com/agera-edc/DataSpaceConnector/actions/runs/1884466607