### PR TITLE
Feature/360/91 cosmosdb emulator

### DIFF
--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -49,6 +49,7 @@ jobs:
       - name: Setup Gradle cache
         uses: gradle/gradle-build-action@v2
 
+      # Cosmos DB Emulator is preinstalled on GitHub Actions workers
       - name: Launch Cosmos DB Emulator
         run: |
           Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"

--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -37,7 +37,6 @@ jobs:
 
     env:
       RUN_INTEGRATION_TEST: true
-      COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
 
     steps:
       - uses: actions/checkout@v2
@@ -50,6 +49,10 @@ jobs:
       - name: Setup Gradle cache
         uses: gradle/gradle-build-action@v2
 
+      - name: Launch Cosmos DB Emulator
+        run: |
+          Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
+          Start-CosmosDbEmulator -Timeout 1200
 
       - name: CosmosDB Transfer Process Store Test
         run: ./gradlew extensions:azure:cosmos:transfer-process-store-cosmos:test

--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -1,9 +1,6 @@
 name: Integration Tests
 
-on:
-  push:
-    branches: [ main ]
-  pull_request_target:
+on: [ push, pull_request ]
 
 jobs:
 
@@ -36,9 +33,7 @@ jobs:
         run: ./gradlew extensions:azure:blobstorage:blob-provision:check
 
   Azure-CosmosDB-Integration-Test:
-    # run only on upstream repo (requires secret access)
-    if: github.repository_owner == 'eclipse-dataspaceconnector'
-    runs-on: ubuntu-latest
+    runs-on: windows-2019
 
     env:
       RUN_INTEGRATION_TEST: true
@@ -51,7 +46,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-          cache: 'gradle'
+
+      - name: Setup Gradle cache
+        uses: gradle/gradle-build-action@v2
+
 
       - name: CosmosDB Transfer Process Store Test
         run: ./gradlew extensions:azure:cosmos:transfer-process-store-cosmos:test

--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -55,6 +55,8 @@ any residue before and after the test.
 The JUnit runner won't pick up integration tests unless the `RUN_INTEGRATION_TEST` environment variable is set to `true`
 . Also, don't forget to define any credentials that are needed.
 
+Cosmos DB integration tests are run by default against a locally running [Cosmos DB Emulator](https://docs.microsoft.com/azure/cosmos-db/local-emulator). You can also use an instance of Cosmos DB running in Azure, in which case you should set the `COSMOS_KEY` environment variable.
+
 ## Running them in the CI pipeline
 
 All integration tests should go into the [integration test workflow](../.github/workflows/integrationtests.yaml),

--- a/extensions/azure/azure-test/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/testfixtures/CosmosTestClient.java
+++ b/extensions/azure/azure-test/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/testfixtures/CosmosTestClient.java
@@ -2,6 +2,7 @@ package org.eclipse.dataspaceconnector.azure.testfixtures;
 
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
+import org.eclipse.dataspaceconnector.common.string.StringUtils;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 
 import java.io.FileInputStream;
@@ -27,7 +28,7 @@ public interface CosmosTestClient {
 
     static CosmosClient createClient() {
         var cosmosKey = propOrEnv("COSMOS_KEY", null);
-        if (cosmosKey != null) {
+        if (!StringUtils.isNullOrBlank(cosmosKey)) {
             return azureClient(cosmosKey);
         } else {
             return localClient();

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
@@ -48,7 +48,7 @@ public class CosmosContractDefinitionStoreIntegrationTest {
     private TypeManager typeManager;
     private CosmosContractDefinitionStore store;
 
-    private static final String PARTITION_KEY_NEW = "test-ap-id1-new";
+    private static final String PARTITION_KEY_AFTER_UPDATE = "test-ap-id1-new";
 
     @BeforeAll
     static void prepareCosmosClient() {
@@ -81,7 +81,7 @@ public class CosmosContractDefinitionStoreIntegrationTest {
     @AfterEach
     void tearDown() {
         container.deleteAllItemsByPartitionKey(new PartitionKey(PARTITION_KEY), new CosmosItemRequestOptions());
-        container.deleteAllItemsByPartitionKey(new PartitionKey(PARTITION_KEY_NEW), new CosmosItemRequestOptions());
+        container.deleteAllItemsByPartitionKey(new PartitionKey(PARTITION_KEY_AFTER_UPDATE), new CosmosItemRequestOptions());
     }
 
     @Test
@@ -299,7 +299,7 @@ public class CosmosContractDefinitionStoreIntegrationTest {
         // modify the object
         var modifiedDef = ContractDefinition.Builder.newInstance().id(def.getId())
                 .contractPolicy(Policy.Builder.newInstance().id("test-cp-id-new").build())
-                .accessPolicy(Policy.Builder.newInstance().id(PARTITION_KEY_NEW).build())
+                .accessPolicy(Policy.Builder.newInstance().id(PARTITION_KEY_AFTER_UPDATE).build())
                 .selectorExpression(AssetSelectorExpression.Builder.newInstance().whenEquals("somekey", "someval").build())
                 .build();
 

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/CosmosContractDefinitionStoreIntegrationTest.java
@@ -34,6 +34,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.dataspaceconnector.contract.definition.store.TestFunctions.PARTITION_KEY;
 import static org.eclipse.dataspaceconnector.contract.definition.store.TestFunctions.generateDefinition;
 import static org.eclipse.dataspaceconnector.contract.definition.store.TestFunctions.generateDocument;
 
@@ -46,6 +47,8 @@ public class CosmosContractDefinitionStoreIntegrationTest {
     private static CosmosDatabase database;
     private TypeManager typeManager;
     private CosmosContractDefinitionStore store;
+
+    private static final String PARTITION_KEY_NEW = "test-ap-id1-new";
 
     @BeforeAll
     static void prepareCosmosClient() {
@@ -77,7 +80,8 @@ public class CosmosContractDefinitionStoreIntegrationTest {
 
     @AfterEach
     void tearDown() {
-        container.deleteAllItemsByPartitionKey(new PartitionKey("test-ap-id1"), new CosmosItemRequestOptions());
+        container.deleteAllItemsByPartitionKey(new PartitionKey(PARTITION_KEY), new CosmosItemRequestOptions());
+        container.deleteAllItemsByPartitionKey(new PartitionKey(PARTITION_KEY_NEW), new CosmosItemRequestOptions());
     }
 
     @Test
@@ -295,7 +299,7 @@ public class CosmosContractDefinitionStoreIntegrationTest {
         // modify the object
         var modifiedDef = ContractDefinition.Builder.newInstance().id(def.getId())
                 .contractPolicy(Policy.Builder.newInstance().id("test-cp-id-new").build())
-                .accessPolicy(Policy.Builder.newInstance().id("test-ap-id-new").build())
+                .accessPolicy(Policy.Builder.newInstance().id(PARTITION_KEY_NEW).build())
                 .selectorExpression(AssetSelectorExpression.Builder.newInstance().whenEquals("somekey", "someval").build())
                 .build();
 

--- a/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/TestFunctions.java
+++ b/extensions/azure/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/definition/store/TestFunctions.java
@@ -9,11 +9,13 @@ import java.util.UUID;
 
 public class TestFunctions {
 
+    public static final String PARTITION_KEY = "test-ap-id1";
+
     public static ContractDefinition generateDefinition() {
         return ContractDefinition.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .contractPolicy(Policy.Builder.newInstance().id("test-cp-id1").build())
-                .accessPolicy(Policy.Builder.newInstance().id("test-ap-id1").build())
+                .accessPolicy(Policy.Builder.newInstance().id(PARTITION_KEY).build())
                 .selectorExpression(AssetSelectorExpression.Builder.newInstance().whenEquals("somekey", "someval").build())
                 .build();
     }


### PR DESCRIPTION
## What this PR changes/adds:

Use Cosmos DB Emulator in CI. The integration test pipeline currently runs only in upstream main, as it requires access to an Azure Cosmos DB instance.

## Why it does that

This allows fully validating changes that affect the Cosmos DB related extensions *before* merging to upstream main, rather than *after*.

## Further notes

One test had a logical issue due to incomplete data cleanup, and was fixed.

Pipeline was run 100 times without failures.

Use gradle-build-action as it does a better job of caching than setup-java, to accelerate the pipeline in most runs (from 12 min without cache to 6 min)

## Linked Issue(s)

#91

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?