### PR TITLE
Feature/618/96 dpf pool

### DIFF
--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
@@ -36,6 +36,7 @@ import org.eclipse.dataspaceconnector.spi.policy.RuleBindingRegistry;
 import org.eclipse.dataspaceconnector.spi.security.PrivateKeyResolver;
 import org.eclipse.dataspaceconnector.spi.system.BaseExtension;
 import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
+import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentationImplementation;
 import org.eclipse.dataspaceconnector.spi.system.Hostname;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
@@ -67,6 +68,7 @@ import static java.util.Optional.ofNullable;
         RemoteMessageDispatcherRegistry.class,
         RetryPolicy.class,
         RuleBindingRegistry.class,
+        ExecutorInstrumentation.class,
 })
 public class CoreServicesExtension implements ServiceExtension {
 
@@ -101,7 +103,7 @@ public class CoreServicesExtension implements ServiceExtension {
      * An optional instrumentor for {@link ExecutorService}. Used by the optional {@code micrometer} module.
      */
     @Inject(required = false)
-    private ExecutorInstrumentation executorInstrumentation;
+    private ExecutorInstrumentationImplementation executorInstrumentationImplementation;
 
     private HealthCheckServiceImpl healthCheckService;
 
@@ -214,10 +216,10 @@ public class CoreServicesExtension implements ServiceExtension {
     }
 
     private ExecutorInstrumentation registerExecutorInstrumentation(ServiceExtensionContext context) {
-        var executorInstrumentationImpl = ofNullable(this.executorInstrumentation).orElse(ExecutorInstrumentation.noop());
+        var executorInstrumentation = ofNullable((ExecutorInstrumentation) this.executorInstrumentationImplementation)
+                .orElse(ExecutorInstrumentation.noop());
         // Register ExecutorImplementation with default noop implementation if none available
-        context.registerService(ExecutorInstrumentation.class, executorInstrumentationImpl);
-        return executorInstrumentationImpl;
+        context.registerService(ExecutorInstrumentation.class, executorInstrumentation);
+        return executorInstrumentation;
     }
-
 }

--- a/core/micrometer/src/main/java/org/eclipse/dataspaceconnector/metrics/micrometer/MicrometerExecutorInstrumentation.java
+++ b/core/micrometer/src/main/java/org/eclipse/dataspaceconnector/metrics/micrometer/MicrometerExecutorInstrumentation.java
@@ -16,17 +16,17 @@ package org.eclipse.dataspaceconnector.metrics.micrometer;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
-import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
+import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentationImplementation;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
- * {@link ExecutorInstrumentation} that decorates executors using wrappers
+ * {@link ExecutorInstrumentationImplementation} that decorates executors using wrappers
  * provided by Micrometer {@link ExecutorServiceMetrics} to report metrics such as thread pool
  * size and execution timings.
  */
-public class MicrometerExecutorInstrumentation implements ExecutorInstrumentation {
+public class MicrometerExecutorInstrumentation implements ExecutorInstrumentationImplementation {
     private final MeterRegistry registry;
 
     public MicrometerExecutorInstrumentation(MeterRegistry registry) {

--- a/core/micrometer/src/main/java/org/eclipse/dataspaceconnector/metrics/micrometer/MicrometerExtension.java
+++ b/core/micrometer/src/main/java/org/eclipse/dataspaceconnector/metrics/micrometer/MicrometerExtension.java
@@ -25,13 +25,13 @@ import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import okhttp3.EventListener;
 import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.system.BaseExtension;
-import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
+import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentationImplementation;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
 @BaseExtension
-@Provides({EventListener.class, ExecutorInstrumentation.class, MeterRegistry.class})
+@Provides({EventListener.class, ExecutorInstrumentationImplementation.class, MeterRegistry.class})
 public class MicrometerExtension implements ServiceExtension {
 
     @EdcSetting
@@ -91,6 +91,6 @@ public class MicrometerExtension implements ServiceExtension {
     }
 
     private void enableExecutorMetrics(ServiceExtensionContext context, MeterRegistry registry) {
-        context.registerService(ExecutorInstrumentation.class, new MicrometerExecutorInstrumentation(registry));
+        context.registerService(ExecutorInstrumentationImplementation.class, new MicrometerExecutorInstrumentation(registry));
     }
 }

--- a/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/DataPlaneAzureStorageExtension.java
+++ b/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/DataPlaneAzureStorageExtension.java
@@ -17,13 +17,12 @@ import net.jodah.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.adapter.BlobAdapterFactory;
 import org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline.AzureStorageDataSinkFactory;
 import org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline.AzureStorageDataSourceFactory;
+import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataTransferExecutorServiceContainer;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
-
-import java.util.concurrent.Executors;
 
 /**
  * Provides support for reading data from an Azure Storage Blob endpoint and sending data to an Azure Storage Blob endpoint.
@@ -35,6 +34,9 @@ public class DataPlaneAzureStorageExtension implements ServiceExtension {
 
     @Inject
     private PipelineService pipelineService;
+
+    @Inject
+    private DataTransferExecutorServiceContainer executorContainer;
 
     @EdcSetting
     public static final String EDC_BLOBSTORE_ENDPOINT = "edc.blobstore.endpoint";
@@ -48,8 +50,6 @@ public class DataPlaneAzureStorageExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         var blobstoreEndpoint = context.getSetting(EDC_BLOBSTORE_ENDPOINT, null);
 
-        var executorService = Executors.newFixedThreadPool(10); // TODO make configurable
-
         var monitor = context.getMonitor();
 
         var blobAdapterFactory = new BlobAdapterFactory(blobstoreEndpoint);
@@ -57,7 +57,7 @@ public class DataPlaneAzureStorageExtension implements ServiceExtension {
         var sourceFactory = new AzureStorageDataSourceFactory(blobAdapterFactory, retryPolicy, monitor);
         pipelineService.registerFactory(sourceFactory);
 
-        var sinkFactory = new AzureStorageDataSinkFactory(blobAdapterFactory, executorService, 5, monitor);
+        var sinkFactory = new AzureStorageDataSinkFactory(blobAdapterFactory, executorContainer.getExecutorService(), 5, monitor);
         pipelineService.registerFactory(sinkFactory);
     }
 }

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtension.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtension.java
@@ -84,8 +84,8 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
         transferServiceRegistry.registerTransferService(transferService);
         context.registerService(TransferServiceRegistry.class, transferServiceRegistry);
 
-        var nThreads = context.getSetting(TRANSFER_THREADS, DEFAULT_TRANSFER_THREADS);
-        var executorContainer = new DataTransferExecutorServiceContainer(Executors.newFixedThreadPool(nThreads));
+        var numThreads = context.getSetting(TRANSFER_THREADS, DEFAULT_TRANSFER_THREADS);
+        var executorContainer = new DataTransferExecutorServiceContainer(Executors.newFixedThreadPool(numThreads));
         context.registerService(DataTransferExecutorServiceContainer.class, executorContainer);
 
         monitor = context.getMonitor();

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtension.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtension.java
@@ -34,7 +34,6 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
 import java.util.Objects;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 /**
@@ -102,6 +101,7 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
 
         dataPlaneManager = DataPlaneManagerImpl.Builder.newInstance()
                 .queueCapacity(queueCapacity)
+                .executorInstrumentation(executorInstrumentation)
                 .workers(workers)
                 .waitTimeout(waitTimeout)
                 .pipelineService(pipelineService)

--- a/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtensionTest.java
+++ b/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtensionTest.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.dataspaceconnector.dataplane.framework;
 
+import org.eclipse.dataspaceconnector.core.executor.NoopExecutorInstrumentation;
 import org.eclipse.dataspaceconnector.dataplane.framework.pipeline.PipelineServiceImpl;
 import org.eclipse.dataspaceconnector.dataplane.framework.registry.TransferServiceSelectionStrategy;
 import org.eclipse.dataspaceconnector.dataplane.spi.manager.DataPlaneManager;
@@ -20,6 +21,7 @@ import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.TransferService;
 import org.eclipse.dataspaceconnector.dataplane.spi.registry.TransferServiceRegistry;
 import org.eclipse.dataspaceconnector.junit.launcher.DependencyInjectionExtension;
+import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.system.injection.ObjectFactory;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
@@ -42,9 +44,10 @@ class DataPlaneFrameworkExtensionTest {
     DataFlowRequest request = createRequest("1").build();
 
     @BeforeEach
-    public void setUp() {
+    public void setUp(ServiceExtensionContext context) {
         when(transferService1.canHandle(request)).thenReturn(true);
         when(transferService2.canHandle(request)).thenReturn(true);
+        context.registerService(ExecutorInstrumentation.class, new NoopExecutorInstrumentation());
     }
 
     @Test

--- a/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtensionTest.java
+++ b/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtensionTest.java
@@ -13,7 +13,6 @@
  */
 package org.eclipse.dataspaceconnector.dataplane.framework;
 
-import org.eclipse.dataspaceconnector.core.executor.NoopExecutorInstrumentation;
 import org.eclipse.dataspaceconnector.dataplane.framework.pipeline.PipelineServiceImpl;
 import org.eclipse.dataspaceconnector.dataplane.framework.registry.TransferServiceSelectionStrategy;
 import org.eclipse.dataspaceconnector.dataplane.spi.manager.DataPlaneManager;
@@ -47,7 +46,7 @@ class DataPlaneFrameworkExtensionTest {
     public void setUp(ServiceExtensionContext context) {
         when(transferService1.canHandle(request)).thenReturn(true);
         when(transferService2.canHandle(request)).thenReturn(true);
-        context.registerService(ExecutorInstrumentation.class, new NoopExecutorInstrumentation());
+        context.registerService(ExecutorInstrumentation.class, ExecutorInstrumentation.noop());
     }
 
     @Test

--- a/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/e2e/EndToEndTest.java
+++ b/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/e2e/EndToEndTest.java
@@ -21,6 +21,7 @@ import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.InputStreamDataSour
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.OutputStreamDataSink;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
 import org.jetbrains.annotations.NotNull;
@@ -45,6 +46,7 @@ public class EndToEndTest {
         var manager = DataPlaneManagerImpl.Builder.newInstance()
                 .monitor(monitor)
                 .pipelineService(pipelineService)
+                .executorInstrumentation(ExecutorInstrumentation.noop())
                 .build();
         manager.start();
         manager.transfer(new InputStreamDataSource("test", new ByteArrayInputStream("bytes".getBytes())), createRequest("1").build()).get();

--- a/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/manager/DataPlaneManagerImplTest.java
+++ b/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/manager/DataPlaneManagerImplTest.java
@@ -19,6 +19,7 @@ import org.eclipse.dataspaceconnector.dataplane.spi.registry.TransferServiceRegi
 import org.eclipse.dataspaceconnector.dataplane.spi.store.DataPlaneStore;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -126,6 +127,7 @@ class DataPlaneManagerImplTest {
         return DataPlaneManagerImpl.Builder.newInstance()
                 .queueCapacity(100)
                 .workers(1)
+                .executorInstrumentation(ExecutorInstrumentation.noop())
                 .waitTimeout(10)
                 .transferServiceRegistry(registry)
                 .store(store)

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/DataPlaneHttpExtension.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/dataspaceconnector/dataplane/http/DataPlaneHttpExtension.java
@@ -17,13 +17,12 @@ import net.jodah.failsafe.RetryPolicy;
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.dataplane.http.pipeline.HttpDataSinkFactory;
 import org.eclipse.dataspaceconnector.dataplane.http.pipeline.HttpDataSourceFactory;
+import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataTransferExecutorServiceContainer;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
-
-import java.util.concurrent.Executors;
 
 /**
  * Provides support for reading data from an HTTP endpoint and sending data to an HTTP endpoint.
@@ -40,6 +39,9 @@ public class DataPlaneHttpExtension implements ServiceExtension {
     @Inject
     private PipelineService pipelineService;
 
+    @Inject
+    private DataTransferExecutorServiceContainer executorContainer;
+
     @Override
     public String name() {
         return "Data Plane HTTP";
@@ -48,14 +50,12 @@ public class DataPlaneHttpExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var vault = context.getService(Vault.class);
-        var executorService = Executors.newFixedThreadPool(10); // TODO make configurable
-
         var monitor = context.getMonitor();
 
         @SuppressWarnings("unchecked") var sourceFactory = new HttpDataSourceFactory(httpClient, retryPolicy, monitor, vault);
         pipelineService.registerFactory(sourceFactory);
 
-        var sinkFactory = new HttpDataSinkFactory(httpClient, executorService, 5, monitor);
+        var sinkFactory = new HttpDataSinkFactory(httpClient, executorContainer.getExecutorService(), 5, monitor);
         pipelineService.registerFactory(sinkFactory);
     }
 }

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/DataTransferExecutorServiceContainer.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/DataTransferExecutorServiceContainer.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Holder class for a shared {@link ExecutorService} across data transfer implementations.
+ */
+public class DataTransferExecutorServiceContainer {
+    private final ExecutorService executorService;
+
+    public DataTransferExecutorServiceContainer(@NotNull ExecutorService executorService) {
+        this.executorService = executorService;
+    }
+
+    public @NotNull ExecutorService getExecutorService() {
+        return executorService;
+    }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ExecutorInstrumentation.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ExecutorInstrumentation.java
@@ -22,7 +22,8 @@ import java.util.concurrent.ScheduledExecutorService;
  * collect execution metrics when available.
  * <p>
  * The default implementation does not provide any instrumentation. Extension
- * modules can provide implementations, such as for collecting metrics.
+ * modules can provide implementations of the {@link ExecutorInstrumentationImplementation} sub-interface,
+ * such as for collecting metrics.
  */
 public interface ExecutorInstrumentation {
     /**

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ExecutorInstrumentationImplementation.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ExecutorInstrumentationImplementation.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.spi.system;
+
+/**
+ * Interface for custom implementations of {@link ExecutorInstrumentation}.
+ * <p>
+ * A distinct interface is needed for dependency injection to resolve the optional
+ * {@link ExecutorInstrumentationImplementation} vs. the mandatory {@link ExecutorInstrumentation}
+ * that is provided by core services, providing a default implementation if none is provided.
+ */
+public interface ExecutorInstrumentationImplementation extends ExecutorInstrumentation {
+}

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ExecutorInstrumentationImplementation.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ExecutorInstrumentationImplementation.java
@@ -19,6 +19,15 @@ package org.eclipse.dataspaceconnector.spi.system;
  * A distinct interface is needed for dependency injection to resolve the optional
  * {@link ExecutorInstrumentationImplementation} vs. the mandatory {@link ExecutorInstrumentation}
  * that is provided by core services, providing a default implementation if none is provided.
+ * <p>
+ * The Micrometer extension provides a {@link ExecutorInstrumentationImplementation}.
+ * The core extension consumes an (optional) {@link ExecutorInstrumentationImplementation}
+ * and registers a {@link ExecutorInstrumentation}
+ * (with either the {@link ExecutorInstrumentationImplementation} instance or a default implementation).
+ * Downstream modules consume a (mandatory) {@link ExecutorInstrumentation}.
+ * <p>
+ * Because of the way dependencies are resolved (with a graph) it's not possible for
+ * the core extension to consume and register the same service.
  */
 public interface ExecutorInstrumentationImplementation extends ExecutorInstrumentation {
 }


### PR DESCRIPTION
## What this PR changes/adds

Share a thread pool across all DPF transfers. Made number of threads configurable.
Instrument the thread pool with metrics.

## Why it does that

 This allows better control of resources.

## Further notes

Had to introduce `ExecutorInstrumentationImplementation` class for better control of optional dependencies.

## Linked Issue(s)

Relates to #96 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
