### PR TITLE
Spike/83 consumer retry

### DIFF
--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -63,6 +63,10 @@ public class CoreTransferExtension implements ServiceExtension {
 
     @EdcSetting
     private static final String TRANSFER_STATE_MACHINE_BATCH_SIZE = "edc.transfer.state-machine.batch-size";
+    @EdcSetting
+    private static final String TRANSFER_SEND_RETRY_LIMIT = "edc.transfer.send.retry.limit";
+    @EdcSetting
+    private static final String TRANSFER_SEND_RETRY_BASE_DELAY_MS = "edc.transfer.send.retry.base-delay.ms";
 
     @Inject
     private TransferProcessStore transferProcessStore;
@@ -134,6 +138,8 @@ public class CoreTransferExtension implements ServiceExtension {
                 .observable(observable)
                 .store(transferProcessStore)
                 .batchSize(context.getSetting(TRANSFER_STATE_MACHINE_BATCH_SIZE, 5))
+                .sendRetryLimit(context.getSetting(TRANSFER_SEND_RETRY_LIMIT, 7))
+                .sendRetryBaseDelay(context.getSetting(TRANSFER_SEND_RETRY_BASE_DELAY_MS, 100L))
                 .build();
 
         context.registerService(TransferProcessManager.class, processManager);

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -247,7 +247,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
             if (retryCount > 0) {
                 var delayStrategy = new ExponentialWaitStrategy(sendRetryBaseDelay);
                 delayStrategy.failures(retryCount);
-                var waitMillis = delayStrategy.waitForMillis();
+                var waitMillis = delayStrategy.retryInMillis();
                 long remainingWaitMillis = process.getStateTimestamp() + waitMillis - clock.millis();
                 if (remainingWaitMillis > 0) {
                     monitor.debug(format("Process %s transfer retry #%d will not be attempted before %d ms.", process.getId(), retryCount, remainingWaitMillis));

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -86,7 +86,7 @@ import static org.mockito.Mockito.when;
 class TransferProcessManagerImplTest {
 
     private static final String DESTINATION_TYPE = "test-type";
-    private static final long TIMEOUT = 5;
+    private static final long TIMEOUT = 10;
     private static final int TRANSFER_MANAGER_BATCHSIZE = 10;
     private final ProvisionManager provisionManager = mock(ProvisionManager.class);
     private final RemoteMessageDispatcherRegistry dispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
@@ -209,9 +209,9 @@ class TransferProcessManagerImplTest {
     }
 
     @Test
-    void requesting_shouldTransitionToRequestedThenToInProgress() throws InterruptedException {
+    void requesting_shouldTransitionToRequested() throws InterruptedException {
         var process = createTransferProcess(REQUESTING);
-        var latch = countDownOnUpdateLatch(2);
+        var latch = countDownOnUpdateLatch(1);
         when(dispatcherRegistry.send(eq(Object.class), any(), any())).thenReturn(completedFuture("any"));
         when(store.nextForState(eq(REQUESTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
         when(store.find(process.getId())).thenReturn(process, process.toBuilder().state(REQUESTED.code()).build());
@@ -220,7 +220,6 @@ class TransferProcessManagerImplTest {
 
         assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
         verify(store, times(1)).update(argThat(p -> p.getState() == REQUESTED.code()));
-        verify(store, times(1)).update(argThat(p -> p.getState() == IN_PROGRESS.code()));
     }
 
     @Test

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -88,7 +88,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class TransferProcessManagerImplTest {
-    static final Faker faker = new Faker();
+    static Faker faker = new Faker();
 
     private static final String DESTINATION_TYPE = "test-type";
     private static final long TIMEOUT = 10;
@@ -294,12 +294,10 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
-        if (beforeTimeout)
-        {
+        if (beforeTimeout) {
             verifyNoInteractions(dispatcherRegistry);
             verify(store, times(1)).update(argThat(p -> p.getState() == REQUESTING.code()));
-        }
-        else {
+        } else {
             verify(store, times(1)).update(argThat(p -> p.getState() == REQUESTED.code()));
         }
     }

--- a/extensions/in-memory/transfer-store-memory/src/main/java/org/eclipse/dataspaceconnector/transfer/store/memory/InMemoryTransferProcessStore.java
+++ b/extensions/in-memory/transfer-store-memory/src/main/java/org/eclipse/dataspaceconnector/transfer/store/memory/InMemoryTransferProcessStore.java
@@ -94,7 +94,6 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
     @Override
     public void update(TransferProcess process) {
         lockManager.writeLock(() -> {
-            process.updateStateTimestamp();
             delete(process.getId());
             TransferProcess internalCopy = process.copy();
             processesByExternalId.put(process.getDataRequest().getId(), internalCopy);

--- a/samples/04.3-open-telemetry/README.md
+++ b/samples/04.3-open-telemetry/README.md
@@ -22,7 +22,7 @@ In addition, the [Jaeger exporter](https://github.com/open-telemetry/opentelemet
 To run the consumer, the provider, and Jaeger execute the following commands in the project root folder:
 
 ```bash
-./gradlew samples:04.3-open-telemetry:consumer:build samples:04.0-file-transfer:provider:build
+./gradlew samples:04.3-open-telemetry:consumer:build samples:04.3-open-telemetry:provider:build
 docker-compose -f samples/04.3-open-telemetry/docker-compose.yaml up --abort-on-container-exit
 ```
 
@@ -45,7 +45,7 @@ Click the globe icon near the top right corner (Metrics Explorer) and select a m
 
 ## Using another monitoring backend
 
-Other monitoring backends can be plugged in easily with OpenTelemetry. For instance, if you want to use Azure Application Insights instead of Jaeger, you can replace the OpenTelemetry Java Agent by the [Application Insights Java Agent](https://docs.microsoft.com/en-us/azure/azure-monitor/app/java-in-process-agent#download-the-jar-file) instead, which has to be stored in the root folder of this sample as well. The only additional configuration required are the `APPLICATIONINSIGHTS_CONNECTION_STRING` and `APPLICATIONINSIGHTS_ROLE_NAME` env variables:
+Other monitoring backends can be plugged in easily with OpenTelemetry. For instance, if you want to use Azure Application Insights instead of Jaeger, you can replace the OpenTelemetry Java Agent by the [Application Insights Java Agent](https://docs.microsoft.com/azure/azure-monitor/app/java-in-process-agent#download-the-jar-file) instead, which has to be stored in the root folder of this sample as well. The only additional configuration required are the `APPLICATIONINSIGHTS_CONNECTION_STRING` and `APPLICATIONINSIGHTS_ROLE_NAME` env variables:
 
 ```yaml
   consumer:
@@ -53,13 +53,22 @@ Other monitoring backends can be plugged in easily with OpenTelemetry. For insta
     environment:
       APPLICATIONINSIGHTS_CONNECTION_STRING: <your-connection-string>
       APPLICATIONINSIGHTS_ROLE_NAME: consumer
-      edc.api.control.auth.apikey.value: password
-      ids.webhook.address: http://consumer:8181
+      # optional: increase log verbosity (default level is INFO)
+      APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL: DEBUG
+      WEB_HTTP_PORT: 8181
+      WEB_HTTP_PATH: /api
+      WEB_HTTP_DATA_PORT: 8182
+      WEB_HTTP_DATA_PATH: /api/v1/data
+      IDS_WEBHOOK_ADDRESS: http://consumer:8181
     volumes:
       - ../:/samples
     ports:
       - 9191:8181
-    entrypoint: java -javaagent:/samples/04.3-open-telemetry/applicationinsights-agent-3.2.5.jar -jar /samples/04.3-open-telemetry/consumer/build/libs/consumer.jar
+      - 9192:8182
+    entrypoint: java
+      -javaagent:/samples/04.3-open-telemetry/applicationinsights-agent-3.2.8.jar
+      -Djava.util.logging.config.file=/samples/04.3-open-telemetry/logging.properties
+      -jar /samples/04.3-open-telemetry/consumer/build/libs/consumer.jar
 ```
 
 The Application Insights Java agent will automatically collect metrics from Micrometer, without any configuration needed.

--- a/samples/04.3-open-telemetry/docker-compose.yaml
+++ b/samples/04.3-open-telemetry/docker-compose.yaml
@@ -9,8 +9,11 @@ services:
       OTEL_TRACES_EXPORTER: jaeger
       OTEL_EXPORTER_JAEGER_ENDPOINT: http://jaeger:14250
       OTEL_METRICS_EXPORTER: prometheus
-      edc.api.control.auth.apikey.value: password
-      ids.webhook.address: http://consumer:8181
+      WEB_HTTP_PORT: 8181
+      WEB_HTTP_PATH: /api
+      WEB_HTTP_DATA_PORT: 8182
+      WEB_HTTP_DATA_PATH: /api/v1/data
+      IDS_WEBHOOK_ADDRESS: http://consumer:8181
     volumes:
       - ../:/samples
     ports:
@@ -18,7 +21,7 @@ services:
       - 9192:8182
     entrypoint: java
       -javaagent:/samples/04.3-open-telemetry/opentelemetry-javaagent.jar
-      -Dedc.fs.config=/samples/04.3-open-telemetry/consumer/config.properties
+      -Djava.util.logging.config.file=/samples/04.3-open-telemetry/logging.properties
       -jar /samples/04.3-open-telemetry/consumer/build/libs/consumer.jar
 
   provider:
@@ -27,7 +30,11 @@ services:
       OTEL_SERVICE_NAME: provider
       OTEL_TRACES_EXPORTER: jaeger
       OTEL_EXPORTER_JAEGER_ENDPOINT: http://jaeger:14250
-      ids.webhook.address: http://provider:8181
+      WEB_HTTP_PORT: 8181
+      WEB_HTTP_PATH: /api
+      WEB_HTTP_DATA_PORT: 8182
+      WEB_HTTP_DATA_PATH: /api/v1/data
+      IDS_WEBHOOK_ADDRESS: http://provider:8181
     volumes:
       - ../:/samples
     ports:
@@ -35,7 +42,7 @@ services:
       - 8182:8182
     entrypoint: java
       -javaagent:/samples/04.3-open-telemetry/opentelemetry-javaagent.jar
-      -Dedc.fs.config=/samples/04.0-file-transfer/provider/config.properties
+      -Djava.util.logging.config.file=/samples/04.3-open-telemetry/logging.properties
       -jar /samples/04.0-file-transfer/provider/build/libs/provider.jar
 
   jaeger:

--- a/samples/04.3-open-telemetry/logging.properties
+++ b/samples/04.3-open-telemetry/logging.properties
@@ -1,0 +1,5 @@
+handlers = java.util.logging.ConsoleHandler
+.level = FINE
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format = %1$tF %1$tT %4$s : %5$s %n

--- a/samples/04.3-open-telemetry/provider/build.gradle.kts
+++ b/samples/04.3-open-telemetry/provider/build.gradle.kts
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - added dependencies
  *       ZF Friedrichshafen AG - add dependency
  *
  */
@@ -24,25 +25,23 @@ val rsApi: String by project
 
 dependencies {
     implementation(project(":core"))
-    implementation(project(":core:micrometer"))
 
     implementation(project(":extensions:in-memory:assetindex-memory"))
     implementation(project(":extensions:in-memory:transfer-store-memory"))
-    implementation(project(":extensions:in-memory:assetindex-memory"))
     implementation(project(":extensions:in-memory:negotiation-store-memory"))
     implementation(project(":extensions:in-memory:contractdefinition-store-memory"))
+
+    implementation(project(":extensions:api:observability"))
 
     implementation(project(":extensions:filesystem:configuration-fs"))
     implementation(project(":extensions:iam:iam-mock"))
 
-    implementation(project(":extensions:api:control"))
     implementation(project(":extensions:api:data-management"))
 
     implementation(project(":data-protocols:ids"))
-    runtimeOnly(project(":extensions:http:jersey-micrometer"))
-    runtimeOnly(project(":extensions:http:jetty-micrometer"))
+
+    implementation(project(":samples:04.0-file-transfer:transfer-file"))
     runtimeOnly(project(":extensions:jdk-logger-monitor"))
-    implementation(project(":samples:04.0-file-transfer:api"))
 }
 
 application {
@@ -52,5 +51,5 @@ application {
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     exclude("**/pom.properties", "**/pom.xm")
     mergeServiceFiles()
-    archiveFileName.set("consumer.jar")
+    archiveFileName.set("provider.jar")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -182,6 +182,7 @@ include(":samples:04.2-modify-transferprocess:simulator")
 
 include(":samples:04.3-open-telemetry:micrometer")
 include(":samples:04.3-open-telemetry:consumer")
+include(":samples:04.3-open-telemetry:provider")
 
 include(":samples:05-file-transfer-cloud:consumer")
 include(":samples:05-file-transfer-cloud:provider")

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/retry/ExponentialWaitStrategy.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/retry/ExponentialWaitStrategy.java
@@ -15,14 +15,15 @@
 
 package org.eclipse.dataspaceconnector.spi.retry;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * Implements an exponential backoff strategy for successive retries.
  */
 public class ExponentialWaitStrategy implements WaitStrategy {
 
     private final long successWaitPeriodMillis;
-    private int errorCount = 0;
-
+    private final AtomicInteger errorCount = new AtomicInteger(0);
 
     public ExponentialWaitStrategy(long successWaitPeriodMillis) {
         this.successWaitPeriodMillis = successWaitPeriodMillis;
@@ -35,15 +36,18 @@ public class ExponentialWaitStrategy implements WaitStrategy {
 
     @Override
     public void success() {
-        errorCount = 0;
+        errorCount.set(0);
+    }
+
+    @Override
+    public void failures(int number) {
+        errorCount.addAndGet(number);
     }
 
     @Override
     public long retryInMillis() {
-        errorCount++;
-        double exponentialMultiplier = Math.pow(2.0, errorCount - 1);
-        double result = exponentialMultiplier * successWaitPeriodMillis;
-        return (long) Math.min(result, Long.MAX_VALUE);
+        var retryCount = errorCount.getAndIncrement();
+        var exponentialMultiplier = 1L << retryCount; // = Math.pow(2, retryCount)
+        return exponentialMultiplier * successWaitPeriodMillis;
     }
-
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/retry/WaitStrategy.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/retry/WaitStrategy.java
@@ -7,11 +7,16 @@ public interface WaitStrategy {
      */
     long waitForMillis();
 
-
     /**
      * Marks the iteration as successful.
      */
     default void success() {
+    }
+
+    /**
+     * Marks the iteration as successful.
+     */
+    default void failures(int number) {
     }
 
     /**


### PR DESCRIPTION
## What this PR changes/adds

Possible solution for consumer side retry. See my comment in upstream issue 336

_In TransferProcessManagerImpl.sendConsumerRequest, if the request fails we should leave the request in REQUESTING state, incrementing the stateCount.

Using the stateCount as a retry counter, we should apply exponential wait between retries, and when a maximum number of retries is reached, transition the transfer process to the ERROR state.

It does not seem necessary to use the Failsafe library for this (which would increase complexity), we can just use the state machine loop, and filter requests ( in REQUESTING state) where the state timestamp plus the exponential wait (based on state count) is before the current time._

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
