### PR TITLE
Run CosmosDB test only if COSMOS_KEY is present

### DIFF
--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -46,6 +46,7 @@ jobs:
 
     env:
       COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
+      COSMOS_URL: ${{ secrets.COSMOS_URL }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -40,6 +40,7 @@ jobs:
 
   Azure-CosmosDB-Integration-Test:
     # run only if COSMOS_KEY is present
+    needs: [ Check-Cosmos-Key ]
     if: needs.Check-Cosmos-Key.outputs.has-cosmos-key == 'true'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -28,7 +28,6 @@ jobs:
         run: ./gradlew -p extensions/azure test -DincludeTags="AzureStorageIntegrationTest"
 
   Check-Cosmos-Key:
-    environment: Azure-dev
     runs-on: ubuntu-latest
     steps:
       - id: has-cosmos-key

--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -27,8 +27,25 @@ jobs:
       - name: Azure Storage Tests
         run: ./gradlew -p extensions/azure test -DincludeTags="AzureStorageIntegrationTest"
 
+  Check-Cosmos-Key:
+    environment: Azure-dev
+    runs-on: ubuntu-latest
+    steps:
+      - id: has-cosmos-key
+        env:
+          HAS_COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
+        if: "${{ env.HAS_COSMOS_KEY != '' }}"
+        run: echo "::set-output name=defined::true"
+    outputs:
+      has-cosmos-key: ${{ steps.has-cosmos-key.outputs.defined }}
+
   Azure-CosmosDB-Integration-Test:
-    runs-on: windows-latest
+    # run only if COSMOS_KEY is present
+    if: needs.Check-Cosmos-Key.outputs.has-cosmos-key == 'true'
+    runs-on: ubuntu-latest
+
+    env:
+      COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
 
     steps:
       - uses: actions/checkout@v2
@@ -38,12 +55,6 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
-
-      # Cosmos DB Emulator is preinstalled on GitHub Actions workers
-      - name: Launch Cosmos DB Emulator
-        run: |
-          Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
-          Start-CosmosDbEmulator -Timeout 1200
 
       - name: Azure CosmosDB Tests
         run: ./gradlew -p extensions/azure/cosmos test -DincludeTags="AzureCosmosDbIntegrationTest"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -90,10 +90,6 @@ As mentioned above the JUnit runner won't pick up integration tests unless a tag
 ./gradlew test -p path/to/module -DincludeTags="AzureCosmosDbIntegrationTest"
 ```
 
-_Cosmos DB integration tests are run by default against a locally running
-[Cosmos DB Emulator](https://docs.microsoft.com/azure/cosmos-db/local-emulator). You can also use an instance of Cosmos
-DB running in Azure, in which case you should set the `COSMOS_KEY` environment variable._
-
 if needed to run all types of tests(e.g. unit & integration) then it can be achieved by passing the `runAllTests=true`
 parameter to the `gradlew` command:
 
@@ -110,7 +106,7 @@ For example to run all integration tests from Azure cosmos db module and its sub
 _Command as `./gradlew :extensions:azure:cosmos test -DincludeTags="AzureCosmosDbIntegrationTest"` does not execute
 tests from all sub-modules so we need to use `-p` to specify the module project path._
 
-Cosmos DB integration tests are run by default against a locally running [Cosmos DB Emulator](https://docs.microsoft.com/azure/cosmos-db/local-emulator). You can also use an instance of Cosmos DB running in Azure, in which case you should set the `COSMOS_KEY` environment variable.
+Cosmos DB integration tests are run by default against a locally running [Cosmos DB Emulator](https://docs.microsoft.com/azure/cosmos-db/local-emulator). You can also use an instance of Cosmos DB running in Azure, in which case you should set the `COSMOS_KEY` and `COSMOS_URL` environment variables.
 
 ### Running them in the CI pipeline
 

--- a/extensions/azure/azure-test/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/testfixtures/CosmosTestClient.java
+++ b/extensions/azure/azure-test/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/testfixtures/CosmosTestClient.java
@@ -29,17 +29,18 @@ public interface CosmosTestClient {
     static CosmosClient createClient() {
         var cosmosKey = propOrEnv("COSMOS_KEY", null);
         if (!StringUtils.isNullOrBlank(cosmosKey)) {
-            return azureClient(cosmosKey);
+            String endpoint = propOrEnv("COSMOS_URL", "https://cosmos-itest.documents.azure.com:443/");
+            return azureClient(cosmosKey, endpoint);
         } else {
             return localClient();
         }
     }
 
-    private static CosmosClient azureClient(String cosmosKey) {
+    private static CosmosClient azureClient(String cosmosKey, String cosmosUrl) {
         return new CosmosClientBuilder()
                 .key(cosmosKey)
                 .preferredRegions(List.of("westeurope"))
-                .endpoint("https://cosmos-itest.documents.azure.com:443/")
+                .endpoint(cosmosUrl)
                 .buildClient();
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Run Cosmos DB tests on a cloud instance in CI, instead of emulator.

## Why it does that

Emulator is not reliable running in GitHub agent.

## Further notes

Adapted one unit test for portability, since deleteAllItemsByPartitionKey is disabled by default on new Cosmos DB accounts.

## Linked Issue(s)

Related to #170 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
