### PR TITLE
EdcRuntimeExtension: Fixed adding resources to class path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ the detailed section referring to by linking pull requests or issues.
 * Flaky S3 StatusChecker Test (#794)
 * Added missing Data Management Asset controller openapi (#853)
 * Policy deserialization (#898)
+* Fix extensions loading of EdcRuntimeExtension (?)
 
 ---
 

--- a/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/EdcRuntimeExtension.java
+++ b/launchers/junit/src/testFixtures/java/org/eclipse/dataspaceconnector/junit/launcher/EdcRuntimeExtension.java
@@ -175,7 +175,7 @@ public class EdcRuntimeExtension extends EdcExtension {
             var buildDir = f.getParentFile().getParentFile();
             return Stream.of(
                     new File(buildDir, "/classes/java/main").toURI().toURL(),
-                    new File(buildDir, "/resources/main").toURI().toURL()
+                    new File(buildDir, "../src/main/resources").toURI().toURL()
             );
         } catch (IOException e) {
             throw new EdcException(e);


### PR DESCRIPTION
## What this PR changes/adds

Looks like resources folder is not added to classpath before test execution of EdcRuntimeExtension. Fixed the path.
Way to test it:

Without the fix, running this command would fail, with the fix it does not fail:
```bash
 ./gradlew clean :system-tests:tests:test
```

## Why it does that

To fix this bug: 
https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/975

## Linked Issue(s)

https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/975

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
