### PR TITLE
CosmosDb integration tests: pick up TransferProcess after the lease expired

### DIFF
--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/build.gradle.kts
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 
 val cosmosSdkVersion: String by project
 val jodahFailsafeVersion: String by project
+val awaitility: String by project
 
 dependencies {
     api(project(":spi:contract-spi"))
@@ -30,6 +31,7 @@ dependencies {
 
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":extensions:azure:azure-test")))
+    testImplementation("org.awaitility:awaitility:${awaitility}")
 }
 
 

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/build.gradle.kts
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
 
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":extensions:azure:azure-test")))
+    testImplementation(testFixtures(project(":extensions:azure:cosmos:cosmos-common")))
     testImplementation("org.awaitility:awaitility:${awaitility}")
 }
 

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -327,8 +327,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
                 .untilAsserted(() -> {
                             List<ContractNegotiation> negotiationsAfterLeaseExpired = store.nextForState(state.code(), 10);
                             assertThat(negotiationsAfterLeaseExpired).hasSize(1).allSatisfy(neg -> assertThat(neg).usingRecursiveComparison().isEqualTo(n));
-                    }
-                );
+                });
     }
 
     @Test

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -55,7 +55,7 @@ import static org.eclipse.dataspaceconnector.azure.cosmos.util.StoredProcedureTe
 import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions.generateDocument;
 import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions.generateNegotiation;
 
-@AzureCosmosDbIntegrationTest
+//@AzureCosmosDbIntegrationTest
 class CosmosContractNegotiationStoreIntegrationTest {
     public static final String CONNECTOR_ID = "test-connector";
     private static final String TEST_ID = UUID.randomUUID().toString();
@@ -311,7 +311,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
         var state = ContractNegotiationStates.CONFIRMED;
         var n = generateNegotiation(state);
         var doc = new ContractNegotiationDocument(n, partitionKey);
-        Duration leaseDuration = Duration.ofMillis(5);
+        Duration leaseDuration = Duration.ofSeconds(5);
         doc.acquireLease("another-connector", leaseDuration);
         container.createItem(doc);
 

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -327,7 +327,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
                 .untilAsserted(() -> {
                             List<ContractNegotiation> negotiationsAfterLeaseExpired = store.nextForState(state.code(), 10);
                             assertThat(negotiationsAfterLeaseExpired).hasSize(1).allSatisfy(neg -> assertThat(neg).usingRecursiveComparison().isEqualTo(n));
-                        }
+                    }
                 );
     }
 

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -325,8 +325,8 @@ class CosmosContractNegotiationStoreIntegrationTest {
                 .pollInterval(Duration.ofSeconds(1))
                 .pollDelay(leaseDuration) //give the lease time to expire
                 .untilAsserted(() -> {
-                            List<ContractNegotiation> negotiationsAfterLeaseExpired = store.nextForState(state.code(), 10);
-                            assertThat(negotiationsAfterLeaseExpired).hasSize(1).allSatisfy(neg -> assertThat(neg).usingRecursiveComparison().isEqualTo(n));
+                    List<ContractNegotiation> negotiationsAfterLeaseExpired = store.nextForState(state.code(), 10);
+                    assertThat(negotiationsAfterLeaseExpired).hasSize(1).allSatisfy(neg -> assertThat(neg).usingRecursiveComparison().isEqualTo(n));
                 });
     }
 

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -325,10 +325,10 @@ class CosmosContractNegotiationStoreIntegrationTest {
                 .pollInterval(Duration.ofSeconds(1))
                 .pollDelay(leaseDuration) //give the lease time to expire
                 .untilAsserted(() -> {
-                    List<ContractNegotiation> negotiationsAfterLeaseExpired = store.nextForState(state.code(), 10);
-                    assertThat(negotiationsAfterLeaseExpired).hasSize(1).allSatisfy(neg -> assertThat(neg).usingRecursiveComparison().isEqualTo(n));
-                }
-        );
+                            List<ContractNegotiation> negotiationsAfterLeaseExpired = store.nextForState(state.code(), 10);
+                            assertThat(negotiationsAfterLeaseExpired).hasSize(1).allSatisfy(neg -> assertThat(neg).usingRecursiveComparison().isEqualTo(n));
+                        }
+                );
     }
 
     @Test

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -55,7 +55,7 @@ import static org.eclipse.dataspaceconnector.azure.cosmos.util.StoredProcedureTe
 import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions.generateDocument;
 import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions.generateNegotiation;
 
-//@AzureCosmosDbIntegrationTest
+@AzureCosmosDbIntegrationTest
 class CosmosContractNegotiationStoreIntegrationTest {
     public static final String CONNECTOR_ID = "test-connector";
     private static final String TEST_ID = UUID.randomUUID().toString();

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -17,7 +17,6 @@ package org.eclipse.dataspaceconnector.contract.negotiation.store;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.implementation.BadRequestException;
-import com.azure.cosmos.models.CosmosStoredProcedureProperties;
 import com.azure.cosmos.models.PartitionKey;
 import net.jodah.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.azure.cosmos.CosmosDbApiImpl;
@@ -45,7 +44,6 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Scanner;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -53,6 +51,7 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
+import static org.eclipse.dataspaceconnector.azure.cosmos.util.StoredProcedureTestUtils.uploadStoredProcedure;
 import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions.generateDocument;
 import static org.eclipse.dataspaceconnector.contract.negotiation.store.TestFunctions.generateNegotiation;
 
@@ -82,27 +81,6 @@ class CosmosContractNegotiationStoreIntegrationTest {
         if (database != null) {
             var delete = database.delete();
             assertThat(delete.getStatusCode()).isBetween(200, 300);
-        }
-    }
-
-    private static void uploadStoredProcedure(CosmosContainer container, String name) {
-        // upload stored procedure
-        var sprocName = ".js";
-        var is = Thread.currentThread().getContextClassLoader().getResourceAsStream(name + sprocName);
-        if (is == null) {
-            throw new AssertionError("The input stream referring to the " + name + " file cannot be null!");
-        }
-
-        var s = new Scanner(is).useDelimiter("\\A");
-        if (!s.hasNext()) {
-            throw new IllegalArgumentException("Error loading resource with name " + sprocName);
-        }
-        var body = s.next();
-        var props = new CosmosStoredProcedureProperties(name, body);
-
-        var scripts = container.getScripts();
-        if (scripts.readAllStoredProcedures().stream().noneMatch(sp -> sp.getId().equals(name))) {
-            scripts.createStoredProcedure(props);
         }
     }
 

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -299,7 +299,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
         var state = ContractNegotiationStates.CONFIRMED;
         var n = generateNegotiation(state);
         var doc = new ContractNegotiationDocument(n, partitionKey);
-        Duration leaseDuration = Duration.ofSeconds(5);
+        Duration leaseDuration = Duration.ofSeconds(2);
         doc.acquireLease("another-connector", leaseDuration);
         container.createItem(doc);
 
@@ -308,8 +308,8 @@ class CosmosContractNegotiationStoreIntegrationTest {
         assertThat(negotiationsBeforeLeaseExpired).isEmpty();
         // after the lease expired
         await()
-                .atMost(Duration.ofSeconds(20))
-                .pollInterval(Duration.ofSeconds(1))
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(500))
                 .pollDelay(leaseDuration) //give the lease time to expire
                 .untilAsserted(() -> {
                     List<ContractNegotiation> negotiationsAfterLeaseExpired = store.nextForState(state.code(), 10);

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -277,18 +277,6 @@ class CosmosContractNegotiationStoreIntegrationTest {
     }
 
     @Test
-    void nextForState_leasedByAnother() {
-        var state = ContractNegotiationStates.CONFIRMED;
-        var n = generateNegotiation(state);
-        var doc = new ContractNegotiationDocument(n, partitionKey);
-        doc.acquireLease("another-connector");
-        container.createItem(doc);
-
-        var result = store.nextForState(state.code(), 10);
-        assertThat(result).isEmpty();
-    }
-
-    @Test
     void nextForState_leasedBySelf() {
         var state = ContractNegotiationStates.CONFIRMED;
         var n = generateNegotiation(state);
@@ -307,7 +295,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
     }
 
     @Test
-    void nextForState_leaseByAnotherExpired() {
+    void nextForState_leasedByAnotherExpired() {
         var state = ContractNegotiationStates.CONFIRMED;
         var n = generateNegotiation(state);
         var doc = new ContractNegotiationDocument(n, partitionKey);
@@ -318,7 +306,6 @@ class CosmosContractNegotiationStoreIntegrationTest {
         // before the lease expired
         var negotiationsBeforeLeaseExpired = store.nextForState(state.code(), 10);
         assertThat(negotiationsBeforeLeaseExpired).isEmpty();
-
         // after the lease expired
         await()
                 .atMost(Duration.ofSeconds(20))

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -285,7 +285,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
 
         // let's verify that the first invocation correctly sets the lease
         var result = store.nextForState(state.code(), 10);
-        assertThat(result).hasSize(1).extracting(ContractNegotiation::getId).containsExactly(n.getId()); //should contain the lease already
+        assertThat(result).hasSize(1); //should contain the lease already
         var storedNegotiation = readItem(n.getId());
         assertThat(storedNegotiation.getLease()).isNotNull().hasFieldOrPropertyWithValue("leasedBy", CONNECTOR_ID);
 

--- a/extensions/azure/cosmos/cosmos-common/build.gradle.kts
+++ b/extensions/azure/cosmos/cosmos-common/build.gradle.kts
@@ -14,6 +14,7 @@
 
 plugins {
     `java-library`
+    `java-test-fixtures`
 }
 
 val cosmosSdkVersion: String by project
@@ -26,9 +27,10 @@ dependencies {
     implementation("com.azure:azure-cosmos:${cosmosSdkVersion}")
     implementation("net.jodah:failsafe:${jodahFailsafeVersion}")
 
-
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":extensions:azure:azure-test")))
+
+    testFixturesImplementation("com.azure:azure-cosmos:${cosmosSdkVersion}")
 }
 
 

--- a/extensions/azure/cosmos/cosmos-common/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/cosmos/util/StoredProcedureTestUtils.java
+++ b/extensions/azure/cosmos/cosmos-common/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/cosmos/util/StoredProcedureTestUtils.java
@@ -15,6 +15,7 @@ public class StoredProcedureTestUtils {
 
     /**
      * Uploads stored procedure into a container.
+     *
      * @param container to upload the stored procedure to
      * @param name of stored procedure js file
      */

--- a/extensions/azure/cosmos/cosmos-common/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/cosmos/util/StoredProcedureTestUtils.java
+++ b/extensions/azure/cosmos/cosmos-common/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/cosmos/util/StoredProcedureTestUtils.java
@@ -1,0 +1,41 @@
+package org.eclipse.dataspaceconnector.azure.cosmos.util;
+
+import com.azure.cosmos.CosmosContainer;
+import com.azure.cosmos.models.CosmosStoredProcedureProperties;
+import org.eclipse.dataspaceconnector.common.annotations.ExcludeFromCodeCoverageGeneratedReport;
+
+import java.util.Scanner;
+
+
+/**
+ * Helper class used in tests to upload stored procedures into CosmosDb container.
+ */
+@ExcludeFromCodeCoverageGeneratedReport
+public class StoredProcedureTestUtils {
+
+    /**
+     * Uploads stored procedure into a container.
+     * @param container to upload the stored procedure to
+     * @param name of stored procedure js file
+     */
+    public static void uploadStoredProcedure(CosmosContainer container, String name) {
+        // upload stored procedure
+        var is = Thread.currentThread().getContextClassLoader().getResourceAsStream(name + ".js");
+        if (is == null) {
+            throw new AssertionError("The input stream referring to the " + name + " file cannot be null!");
+        }
+
+        var s = new Scanner(is).useDelimiter("\\A");
+        if (!s.hasNext()) {
+            throw new IllegalArgumentException("Error loading resource with name " + ".js");
+        }
+        var body = s.next();
+        var props = new CosmosStoredProcedureProperties(name, body);
+
+        var scripts = container.getScripts();
+        if (scripts.readAllStoredProcedures().stream().noneMatch(sp -> sp.getId().equals(name))) {
+            scripts.createStoredProcedure(props);
+        }
+    }
+
+}

--- a/extensions/azure/cosmos/cosmos-common/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/cosmos/util/StoredProcedureTestUtils.java
+++ b/extensions/azure/cosmos/cosmos-common/src/testFixtures/java/org/eclipse/dataspaceconnector/azure/cosmos/util/StoredProcedureTestUtils.java
@@ -1,3 +1,16 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
 package org.eclipse.dataspaceconnector.azure.cosmos.util;
 
 import com.azure.cosmos.CosmosContainer;

--- a/extensions/azure/cosmos/transfer-process-store-cosmos/build.gradle.kts
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 
 val cosmosSdkVersion: String by project
 val jodahFailsafeVersion: String by project
+val awaitility: String by project
 
 dependencies {
     api(project(":spi:transfer-spi"))
@@ -29,6 +30,7 @@ dependencies {
 
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":extensions:azure:azure-test")))
+    testImplementation("org.awaitility:awaitility:${awaitility}")
 }
 
 

--- a/extensions/azure/cosmos/transfer-process-store-cosmos/build.gradle.kts
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
 
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":extensions:azure:azure-test")))
+    testImplementation(testFixtures(project(":extensions:azure:cosmos:cosmos-common")))
     testImplementation("org.awaitility:awaitility:${awaitility}")
 }
 

--- a/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
@@ -194,10 +194,10 @@ class CosmosTransferProcessStoreIntegrationTest {
         List<TransferProcess> processesBeforeLeaseBreak = store.nextForState(TransferProcessStates.INITIAL.code(), 2);
         assertThat(processesBeforeLeaseBreak).isEmpty();
 
-        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(2)).pollDelay(Duration.ofSeconds(5)).untilAsserted( () -> {
-            List<TransferProcess> processesAfterLeaseBreak = store.nextForState(TransferProcessStates.INITIAL.code(), 2);
-            assertThat(processesAfterLeaseBreak).hasSize(1);
-            }
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofSeconds(2)).pollDelay(Duration.ofSeconds(5)).untilAsserted(() -> {
+                    List<TransferProcess> processesAfterLeaseBreak = store.nextForState(TransferProcessStates.INITIAL.code(), 2);
+                    assertThat(processesAfterLeaseBreak).hasSize(1);
+                }
         );
     }
 

--- a/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
@@ -183,7 +183,7 @@ class CosmosTransferProcessStoreIntegrationTest {
                 .untilAsserted(() -> {
                             List<TransferProcess> processesAfterLeaseBreak = store.nextForState(TransferProcessStates.INITIAL.code(), 10);
                             assertThat(processesAfterLeaseBreak).hasSize(1);
-                        }
+                    }
                 );
     }
 

--- a/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
@@ -181,10 +181,10 @@ class CosmosTransferProcessStoreIntegrationTest {
                 .pollInterval(Duration.ofSeconds(1))
                 .pollDelay(leaseDuration) //give the lease time to expire
                 .untilAsserted(() -> {
-                    List<TransferProcess> processesAfterLeaseBreak = store.nextForState(TransferProcessStates.INITIAL.code(), 10);
-                    assertThat(processesAfterLeaseBreak).hasSize(1);
-                }
-        );
+                            List<TransferProcess> processesAfterLeaseBreak = store.nextForState(TransferProcessStates.INITIAL.code(), 10);
+                            assertThat(processesAfterLeaseBreak).hasSize(1);
+                        }
+                );
     }
 
     @Test

--- a/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
@@ -183,8 +183,7 @@ class CosmosTransferProcessStoreIntegrationTest {
                 .untilAsserted(() -> {
                             List<TransferProcess> processesAfterLeaseBreak = store.nextForState(TransferProcessStates.INITIAL.code(), 10);
                             assertThat(processesAfterLeaseBreak).hasSize(1);
-                    }
-                );
+                });
     }
 
     @Test

--- a/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
@@ -181,8 +181,8 @@ class CosmosTransferProcessStoreIntegrationTest {
                 .pollInterval(Duration.ofSeconds(1))
                 .pollDelay(leaseDuration) //give the lease time to expire
                 .untilAsserted(() -> {
-                            List<TransferProcess> processesAfterLeaseBreak = store.nextForState(TransferProcessStates.INITIAL.code(), 10);
-                            assertThat(processesAfterLeaseBreak).hasSize(1);
+                    List<TransferProcess> processesAfterLeaseBreak = store.nextForState(TransferProcessStates.INITIAL.code(), 10);
+                    assertThat(processesAfterLeaseBreak).hasSize(1);
                 });
     }
 

--- a/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
@@ -182,7 +182,7 @@ class CosmosTransferProcessStoreIntegrationTest {
                 .pollDelay(leaseDuration) //give the lease time to expire
                 .untilAsserted(() -> {
                     List<TransferProcess> processesAfterLeaseBreak = store.nextForState(TransferProcessStates.INITIAL.code(), 10);
-                    assertThat(processesAfterLeaseBreak).hasSize(1);
+                    assertThat(processesAfterLeaseBreak).hasSize(1).allSatisfy(transferProcess -> assertThat(transferProcess).usingRecursiveComparison().isEqualTo(tp));
                 });
     }
 

--- a/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
@@ -169,7 +169,7 @@ class CosmosTransferProcessStoreIntegrationTest {
         String id1 = UUID.randomUUID().toString();
         var tp = createTransferProcess(id1, TransferProcessStates.INITIAL);
         TransferProcessDocument item = new TransferProcessDocument(tp, partitionKey);
-        Duration leaseDuration = Duration.ofSeconds(5);
+        Duration leaseDuration = Duration.ofSeconds(2);
         item.acquireLease("another-connector", leaseDuration);
         container.upsertItem(item);
 
@@ -177,8 +177,8 @@ class CosmosTransferProcessStoreIntegrationTest {
         assertThat(processesBeforeLeaseBreak).isEmpty();
 
         await()
-                .atMost(Duration.ofSeconds(20))
-                .pollInterval(Duration.ofSeconds(1))
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(500))
                 .pollDelay(leaseDuration) //give the lease time to expire
                 .untilAsserted(() -> {
                     List<TransferProcess> processesAfterLeaseBreak = store.nextForState(TransferProcessStates.INITIAL.code(), 10);


### PR DESCRIPTION
## What this PR changes/adds

#no-changelog
Added test to CosmosTransferProcessStoreIntegrationTest to cover scenario when item is processed after the lease expired.

## Why it does that

Ensure that lease mechanism works correctly in a situation when the lease of the item expired. 
Example use case: if the processing fails in one instance of the connector then another instance should be able to picks up the processing after the lease of the item expired. 

## Further notes

- Method `uploadStoredProcedure` moved into newly created `StoredProcedureTestUtils` class in cosmos-commons test fixtures to avoid duplicated code.
- Small clean ups in CosmosTransferProcessStoreIntegrationTest and CosmosContractNegotiationStoreIntegrationTest
- ADR about the lease mechanism will be done in another PR.

## Linked Issue(s)

Linked to #82  

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
