### PR TITLE
Feature/991/68 checkstyle unused import

### DIFF
--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/string/StringUtils.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/string/StringUtils.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.common.string;
 
-import java.util.List;
 import java.util.Objects;
 
 public class StringUtils {

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/string/StringUtilsTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/string/StringUtilsTest.java
@@ -16,10 +16,6 @@ package org.eclipse.dataspaceconnector.common.string;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 class StringUtilsTest {

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ContractOfferHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ContractOfferHandler.java
@@ -28,7 +28,6 @@ import org.eclipse.dataspaceconnector.spi.contract.negotiation.ConsumerContractN
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.ProviderContractNegotiationManager;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/DescriptionHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/DescriptionHandler.java
@@ -29,7 +29,6 @@ import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/Handler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/Handler.java
@@ -17,7 +17,6 @@ package org.eclipse.dataspaceconnector.ids.api.multipart.handler;
 import org.eclipse.dataspaceconnector.ids.api.multipart.message.MultipartRequest;
 import org.eclipse.dataspaceconnector.ids.api.multipart.message.MultipartResponse;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/NotificationMessageHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/NotificationMessageHandler.java
@@ -19,7 +19,6 @@ import de.fraunhofer.iais.eis.NotificationMessage;
 import org.eclipse.dataspaceconnector.ids.api.multipart.message.MultipartRequest;
 import org.eclipse.dataspaceconnector.ids.api.multipart.message.MultipartResponse;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ArtifactDescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ArtifactDescriptionRequestHandler.java
@@ -21,7 +21,6 @@ import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/DataCatalogDescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/DataCatalogDescriptionRequestHandler.java
@@ -22,7 +22,6 @@ import org.eclipse.dataspaceconnector.ids.spi.service.CatalogService;
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.jetbrains.annotations.NotNull;
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/DescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/DescriptionRequestHandler.java
@@ -17,7 +17,6 @@ package org.eclipse.dataspaceconnector.ids.api.multipart.handler.description;
 import de.fraunhofer.iais.eis.DescriptionRequestMessage;
 import org.eclipse.dataspaceconnector.ids.api.multipart.message.MultipartResponse;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/RepresentationDescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/RepresentationDescriptionRequestHandler.java
@@ -21,7 +21,6 @@ import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ResourceDescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/ResourceDescriptionRequestHandler.java
@@ -25,7 +25,6 @@ import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/message/MultipartRequest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/dataspaceconnector/ids/api/multipart/message/MultipartRequest.java
@@ -16,7 +16,6 @@ package org.eclipse.dataspaceconnector.ids.api.multipart.message;
 
 import de.fraunhofer.iais.eis.Message;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/ArtifactRequestHandlerTest.java
@@ -28,7 +28,6 @@ import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNeg
 import org.eclipse.dataspaceconnector.spi.contract.validation.ContractValidationService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResult;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/NotificationMessageHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/NotificationMessageHandlerTest.java
@@ -24,7 +24,6 @@ import de.fraunhofer.iais.eis.RejectionMessage;
 import org.eclipse.dataspaceconnector.ids.api.multipart.message.MultipartRequest;
 import org.eclipse.dataspaceconnector.ids.api.multipart.message.MultipartResponse;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/DescriptionHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/dataspaceconnector/ids/api/multipart/handler/description/DescriptionHandlerTest.java
@@ -22,7 +22,6 @@ import org.eclipse.dataspaceconnector.ids.api.multipart.message.MultipartRespons
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImpl.java
@@ -20,12 +20,9 @@ import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
-import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
 import java.util.Objects;
 
 import static java.util.stream.Collectors.toList;

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImpl.java
@@ -21,7 +21,6 @@ import org.eclipse.dataspaceconnector.ids.spi.types.Connector;
 import org.eclipse.dataspaceconnector.ids.spi.version.ConnectorVersionProvider;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.jetbrains.annotations.NotNull;
 

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/CatalogServiceImplTest.java
@@ -19,7 +19,6 @@ import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferQuery;
 import org.eclipse.dataspaceconnector.spi.contract.offer.ContractOfferService;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/service/ConnectorServiceImplTest.java
@@ -20,7 +20,6 @@ import org.eclipse.dataspaceconnector.ids.spi.types.SecurityProfile;
 import org.eclipse.dataspaceconnector.ids.spi.version.ConnectorVersionProvider;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/CatalogService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/CatalogService.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.ids.spi.service;
 
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.catalog.Catalog;
 import org.jetbrains.annotations.NotNull;
 

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/ConnectorService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/service/ConnectorService.java
@@ -17,7 +17,6 @@ package org.eclipse.dataspaceconnector.ids.spi.service;
 
 import org.eclipse.dataspaceconnector.ids.spi.types.Connector;
 import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApi.java
+++ b/extensions/api/data-management/asset/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApi.java
@@ -3,7 +3,6 @@ package org.eclipse.dataspaceconnector.api.datamanagement.asset;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import org.eclipse.dataspaceconnector.api.datamanagement.asset.model.AssetDto;
 import org.eclipse.dataspaceconnector.api.datamanagement.asset.model.AssetEntryDto;
-import org.eclipse.dataspaceconnector.api.datamanagement.asset.model.TransferRequestDto;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 
 import java.util.List;

--- a/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
+++ b/extensions/api/data-management/contractnegotiation/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
@@ -20,7 +20,6 @@ import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractOfferRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/extensions/aws/s3/s3-data-operator/src/main/java/org/eclipse/dataspaceconnector/aws/s3/operator/S3BucketWriter.java
+++ b/extensions/aws/s3/s3-data-operator/src/main/java/org/eclipse/dataspaceconnector/aws/s3/operator/S3BucketWriter.java
@@ -11,13 +11,8 @@ import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.transfer.inline.DataWriter;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
-import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import java.io.InputStream;

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/manager/DataPlaneManagerImpl.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/manager/DataPlaneManagerImpl.java
@@ -17,7 +17,6 @@ import org.eclipse.dataspaceconnector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSink;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.PipelineService;
-import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.TransferService;
 import org.eclipse.dataspaceconnector.dataplane.spi.registry.TransferServiceRegistry;
 import org.eclipse.dataspaceconnector.dataplane.spi.result.TransferResult;
 import org.eclipse.dataspaceconnector.dataplane.spi.store.DataPlaneStore;
@@ -26,8 +25,6 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
 
-import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/manager/DataPlaneManager.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/manager/DataPlaneManager.java
@@ -15,7 +15,6 @@ package org.eclipse.dataspaceconnector.dataplane.spi.manager;
 
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSink;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSource;
-import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.TransferService;
 import org.eclipse.dataspaceconnector.dataplane.spi.result.TransferResult;
 import org.eclipse.dataspaceconnector.dataplane.spi.store.DataPlaneStore.State;
 import org.eclipse.dataspaceconnector.spi.result.Result;

--- a/extensions/filesystem/configuration-fs/src/test/java/org/eclipse/dataspaceconnector/configuration/fs/FsConfigurationExtensionTest.java
+++ b/extensions/filesystem/configuration-fs/src/test/java/org/eclipse/dataspaceconnector/configuration/fs/FsConfigurationExtensionTest.java
@@ -24,10 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class FsConfigurationExtensionTest {

--- a/extensions/http/jetty-micrometer/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyMicrometerConfiguration.java
+++ b/extensions/http/jetty-micrometer/src/main/java/org/eclipse/dataspaceconnector/extension/jetty/JettyMicrometerConfiguration.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.extension.jetty;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.jetty.JettyConnectionMetrics;
 import org.eclipse.jetty.server.ServerConnector;

--- a/extensions/iam/daps/src/test/java/org/eclipse/dataspaceconnector/iam/daps/DapsIntegrationTest.java
+++ b/extensions/iam/daps/src/test/java/org/eclipse/dataspaceconnector/iam/daps/DapsIntegrationTest.java
@@ -24,8 +24,6 @@ import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.security.CertificateResolver;
 import org.eclipse.dataspaceconnector.spi.security.PrivateKeyResolver;
 import org.eclipse.dataspaceconnector.spi.security.Vault;
-import org.eclipse.dataspaceconnector.spi.system.ConfigurationExtension;
-import org.eclipse.dataspaceconnector.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/extensions/in-memory/assetindex-memory/src/main/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndex.java
+++ b/extensions/in-memory/assetindex-memory/src/main/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryAssetIndex.java
@@ -20,7 +20,6 @@ import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
 import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
 import org.eclipse.dataspaceconnector.spi.asset.AssetSelectorExpression;
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
-import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;

--- a/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryDataAddressResolverTest.java
+++ b/extensions/in-memory/assetindex-memory/src/test/java/org/eclipse/dataspaceconnector/metadata/memory/InMemoryDataAddressResolverTest.java
@@ -1,7 +1,6 @@
 package org.eclipse.dataspaceconnector.metadata.memory;
 
 import org.assertj.core.api.Assertions;
-import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.BeforeEach;

--- a/extensions/in-memory/transfer-store-memory/src/test/java/org/eclipse/dataspaceconnector/transfer/store/memory/InMemoryTransferProcessStoreTest.java
+++ b/extensions/in-memory/transfer-store-memory/src/test/java/org/eclipse/dataspaceconnector/transfer/store/memory/InMemoryTransferProcessStoreTest.java
@@ -39,7 +39,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class InMemoryTransferProcessStoreTest {
     private InMemoryTransferProcessStore store;

--- a/extensions/sql/common/src/main/java/org/eclipse/dataspaceconnector/sql/ConnectionFactory.java
+++ b/extensions/sql/common/src/main/java/org/eclipse/dataspaceconnector/sql/ConnectionFactory.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.sql;
 
 import java.sql.Connection;
-import java.sql.SQLException;
 
 /**
  * A ConnectionFactory combines a set of connection configuration

--- a/extensions/sql/common/src/main/java/org/eclipse/dataspaceconnector/sql/pool/ConnectionPool.java
+++ b/extensions/sql/common/src/main/java/org/eclipse/dataspaceconnector/sql/pool/ConnectionPool.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.sql.pool;
 
 import java.sql.Connection;
-import java.sql.SQLException;
 
 /**
  * The ConnectionPool maintains a cache of reusable {@link java.sql.Connection}s.

--- a/extensions/transaction/transaction-atomikos/src/test/java/org/eclipse/dataspaceconnector/transaction/atomikos/JdbcTestFixtures.java
+++ b/extensions/transaction/transaction-atomikos/src/test/java/org/eclipse/dataspaceconnector/transaction/atomikos/JdbcTestFixtures.java
@@ -19,12 +19,9 @@ import org.eclipse.dataspaceconnector.spi.system.configuration.ConfigFactory;
 import java.util.HashMap;
 
 import static org.eclipse.dataspaceconnector.transaction.atomikos.DataSourceConfiguration.DataSourceType.NON_XA;
-import static org.eclipse.dataspaceconnector.transaction.atomikos.DataSourceConfigurationKeys.CONNECTION_TIMEOUT;
 import static org.eclipse.dataspaceconnector.transaction.atomikos.DataSourceConfigurationKeys.DRIVER_CLASS;
 import static org.eclipse.dataspaceconnector.transaction.atomikos.DataSourceConfigurationKeys.DS_TYPE;
-import static org.eclipse.dataspaceconnector.transaction.atomikos.DataSourceConfigurationKeys.LOGIN_TIMEOUT;
 import static org.eclipse.dataspaceconnector.transaction.atomikos.DataSourceConfigurationKeys.URL;
-import static org.eclipse.dataspaceconnector.transaction.atomikos.TransactionManagerConfigurationKeys.LOGGING;
 import static org.eclipse.dataspaceconnector.transaction.atomikos.TransactionManagerConfigurationKeys.TIMEOUT;
 
 /**

--- a/resources/edc-checkstyle-config.xml
+++ b/resources/edc-checkstyle-config.xml
@@ -376,5 +376,6 @@
              default="checkstyle-xpath-suppressions.xml" />
       <property name="optional" value="true"/>
     </module>
+    <module name="UnusedImports"/>
   </module>
 </module>

--- a/samples/other/custom-runtime/src/main/java/org/eclipse/dataspaceconnector/demo/runtime/CustomRuntime.java
+++ b/samples/other/custom-runtime/src/main/java/org/eclipse/dataspaceconnector/demo/runtime/CustomRuntime.java
@@ -11,8 +11,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-import static org.eclipse.dataspaceconnector.boot.system.ExtensionLoader.loadTelemetry;
-
 public class CustomRuntime extends BaseRuntime {
 
     /**

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/BaseCriterionToPredicateConverter.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/query/BaseCriterionToPredicateConverter.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Predicate;
-import java.util.regex.Pattern;
 
 /**
  * Converts a {@link Criterion} into a {@link Predicate} of any given type.

--- a/system-tests/runtimes/file-transfer-consumer/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ApiEndpointExtension.java
+++ b/system-tests/runtimes/file-transfer-consumer/src/main/java/org/eclipse/dataspaceconnector/extensions/api/ApiEndpointExtension.java
@@ -21,14 +21,9 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.ProvisionedResource;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.StatusChecker;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.StatusCheckerRegistry;
-import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 
 import java.io.File;
-import java.nio.file.Path;
-import java.util.List;
 
 public class ApiEndpointExtension implements ServiceExtension {
     @Inject


### PR DESCRIPTION
## What this PR changes/adds

Add a rule to fail build on unused imports.

## Why it does that

Remove unnecessary coupling and dependencies, and reduce PR diffs.

## Further notes

## Linked Issue(s)

Relates to #68

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
