### PR TITLE
CosmosDb lease mechanism: ADR

### DIFF
--- a/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
+++ b/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
@@ -1,4 +1,4 @@
-# CosmosDb lease mechanism
+# Cosmos DB lease mechanism
 
 ## Decision
 
@@ -31,6 +31,6 @@ CosmosDb stores are using 2 stored procedures that handle the lease logic:
 
 1. [`nextForState.js`](/extensions/azure/cosmos/cosmos-common/src/main/resources/nextForState.js) - queries the database to look for all items that has no
    lease or expired lease. It applies a new lease on all returned items. This
-   stored procedure is used to get all elements that are next to process for given state.
+   stored procedure is used to get batch of elements that are next to be processed for given state.
 
 More about stored procedures in CosmosDb: [stored procedures doc](https://docs.microsoft.com/rest/api/cosmos-db/stored-procedures).

--- a/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
+++ b/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
@@ -15,7 +15,8 @@ introduced in the transfer and contract negotiation processes.
 Cosmos document is extended with lease information: a lease holder, time when the lease was acquired and a lease duration.
 
 Lease acts as an exclusive lock: a party leasing a document owns an exclusive lock until the lease expires or it has been explicitly broken.
-Any attempt to acquire or break the lease on a document that has been leased by someone else results in an exception.
+Any attempt to acquire or break the lease on a document that has been leased by someone else results in an exception. If lease is not removed by a
+holder then it expires after some duration. Currently, the lease duration is hardcoded to 60 seconds.
 
 CosmosDb stores are using 2 stored procedures that handle the lease logic:
 

--- a/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
+++ b/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
@@ -14,7 +14,7 @@ Cosmos document is extended with lease information: a lease holder, time when th
 
 Lease acts as an exclusive lock: a party leasing a document owns an exclusive lock until the lease expires or it has been explicitly broken. Any attempt to acquire or break the lease on a document that has been leased by someone else results in an exception. Currently, the lease expiration time is hardcoded to 60 seconds.
 
-CosmosDb stores are using 2 stored procedures that handle the lease logic:
+Cosmos DB stores are using 2 stored procedures that handle the lease logic:
 
 1. [`lease.js`](/extensions/azure/cosmos/cosmos-common/src/main/resources/lease.js) - queries the database to look for an item and if an item is found applies a lease on it. It's used to acquire the lock on single item in the database before an update and to remove the lock after.
 
@@ -26,4 +26,4 @@ CosmosDb stores are using 2 stored procedures that handle the lease logic:
 
 1. [`nextForState.js`](/extensions/azure/cosmos/cosmos-common/src/main/resources/nextForState.js) - queries the database to look for all items that has no lease or expired lease. It applies a new lease on all returned items. This stored procedure is used to get batch of elements that are next to be processed for given state.
 
-More about stored procedures in CosmosDb: [stored procedures doc](https://docs.microsoft.com/rest/api/cosmos-db/stored-procedures).
+More about stored procedures in Cosmos DB: [stored procedures doc](https://docs.microsoft.com/rest/api/cosmos-db/stored-procedures).

--- a/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
+++ b/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
@@ -10,21 +10,28 @@ If a connector fails after receiving a request, a process needs to be picked up 
 when deploying to Kubernetes, since pods can be restarted at any time (e.g. VM autoscale). To ensure a resilient behavior a lease mechanism must be 
 introduced in the transfer and contract negotiation processes.
 
-
 ## Approach
 
-Information about lease is stored in LeaseableCosmosDocument class that extends the {@link CosmosDocument}. Lease stores information about the lease holder, 
-acquiring lease timestamp and a lease duration. See [Lease.java](/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/persistence/Lease.java) 
+Cosmos document is extended with lease information: lease holder, time when the lease was acquired and a lease duration.
  
 Lease acts as an exclusive lock: a party leasing a document owns an exclusive lock until the lease expires or it has been explicitly broken. 
 Any attempt to acquire or break the lease on a document that has been leased by someone else results in an exception.
 
 CosmosDb stores are using 2 stored procedures:
 
-1. `lease` - queries the database to look for an item and if an item is found applies a lease on it. It's used to aquire the lock on single item in the 
-   database.
-2. `nextForState` - queries the database to look for all items that has no lease or expired lease. It applies a new lease on all returned items. This stored 
-   procedure is used to get all elements that are next to process for given state.
+1. [`lease.js`](/extensions/azure/cosmos/cosmos-common/src/main/resources/lease.js) - queries the database to look for an item and if an item is found 
+   applies a lease on it. It's used to acquire the lock on single item in the 
+   database during updating an item.
+
+```java
+   leaseContext.acquireLease(process.getId());
+   failsafeExecutor.run(() -> cosmosDbApi.saveItem(document));
+   leaseContext.breakLease(process.getId());
+```
+
+2. [`nextForState.js`](/extensions/azure/cosmos/cosmos-common/src/main/resources/nextForState.js) - queries the database to look for all items that has no 
+   lease or expired lease. It applies a new lease on all returned items. This 
+   stored procedure is used to get all elements that are next to process for given state.
 
 More about stored procedures in CosmosDb: [stored procedures doc](https://docs.microsoft.com/en-us/rest/api/cosmos-db/stored-procedures).
 

--- a/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
+++ b/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
@@ -15,8 +15,7 @@ introduced in the transfer and contract negotiation processes.
 Cosmos document is extended with lease information: a lease holder, time when the lease was acquired and a lease duration.
 
 Lease acts as an exclusive lock: a party leasing a document owns an exclusive lock until the lease expires or it has been explicitly broken.
-Any attempt to acquire or break the lease on a document that has been leased by someone else results in an exception. If lease is not removed by a
-holder then it expires after some duration. Currently, the lease duration is hardcoded to 60 seconds.
+Any attempt to acquire or break the lease on a document that has been leased by someone else results in an exception. Currently, the lease expiration time is hardcoded to 60 seconds.
 
 CosmosDb stores are using 2 stored procedures that handle the lease logic:
 

--- a/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
+++ b/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
@@ -1,0 +1,30 @@
+# CosmosDb lease mechanism
+
+## Decision
+
+Cosmos DB stores for managing contract negotiations and data transfers should use a lease mechanism to control the processing of the items. 
+
+## Rationale
+
+If a connector fails after receiving a request, a process needs to be picked up by another connector instance. This is specially important 
+when deploying to Kubernetes, since pods can be restarted at any time (e.g. VM autoscale). To ensure a resilient behavior a lease mechanism must be 
+introduced in the transfer and contract negotiation processes.
+
+
+## Approach
+
+Information about lease is stored in LeaseableCosmosDocument class that extends the {@link CosmosDocument}. Lease stores information about the lease holder, 
+acquiring lease timestamp and a lease duration. See [Lease.java](/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/persistence/Lease.java) 
+ 
+Lease acts as an exclusive lock: a party leasing a document owns an exclusive lock until the lease expires or it has been explicitly broken. 
+Any attempt to acquire or break the lease on a document that has been leased by someone else results in an exception.
+
+CosmosDb stores are using 2 stored procedures:
+
+1. `lease` - queries the database to look for an item and if an item is found applies a lease on it. It's used to aquire the lock on single item in the 
+   database.
+2. `nextForState` - queries the database to look for all items that has no lease or expired lease. It applies a new lease on all returned items. This stored 
+   procedure is used to get all elements that are next to process for given state.
+
+More about stored procedures in CosmosDb: [stored procedures doc](https://docs.microsoft.com/en-us/rest/api/cosmos-db/stored-procedures).
+

--- a/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
+++ b/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
@@ -2,25 +2,25 @@
 
 ## Decision
 
-Cosmos DB stores for managing contract negotiations and data transfers should use a lease mechanism to control the processing of the items. 
+Cosmos DB stores for managing contract negotiations and data transfers should use a lease mechanism to control the processing of the items.
 
 ## Rationale
 
-If a connector fails after receiving a request, a process needs to be picked up by another connector instance. This is specially important 
-when deploying to Kubernetes, since pods can be restarted at any time (e.g. VM autoscale). To ensure a resilient behavior a lease mechanism must be 
+If a connector fails after receiving a request, a process needs to be picked up by another connector instance. This is specially important
+when deploying to Kubernetes, since pods can be restarted at any time (e.g. VM autoscale). To ensure a resilient behavior a lease mechanism must be
 introduced in the transfer and contract negotiation processes.
 
 ## Approach
 
 Cosmos document is extended with lease information: lease holder, time when the lease was acquired and a lease duration.
- 
-Lease acts as an exclusive lock: a party leasing a document owns an exclusive lock until the lease expires or it has been explicitly broken. 
+
+Lease acts as an exclusive lock: a party leasing a document owns an exclusive lock until the lease expires or it has been explicitly broken.
 Any attempt to acquire or break the lease on a document that has been leased by someone else results in an exception.
 
 CosmosDb stores are using 2 stored procedures:
 
-1. [`lease.js`](/extensions/azure/cosmos/cosmos-common/src/main/resources/lease.js) - queries the database to look for an item and if an item is found 
-   applies a lease on it. It's used to acquire the lock on single item in the 
+1. [`lease.js`](/extensions/azure/cosmos/cosmos-common/src/main/resources/lease.js) - queries the database to look for an item and if an item is found
+   applies a lease on it. It's used to acquire the lock on single item in the
    database during updating an item.
 
 ```java
@@ -29,9 +29,8 @@ CosmosDb stores are using 2 stored procedures:
    leaseContext.breakLease(process.getId());
 ```
 
-2. [`nextForState.js`](/extensions/azure/cosmos/cosmos-common/src/main/resources/nextForState.js) - queries the database to look for all items that has no 
-   lease or expired lease. It applies a new lease on all returned items. This 
+1. [`nextForState.js`](/extensions/azure/cosmos/cosmos-common/src/main/resources/nextForState.js) - queries the database to look for all items that has no
+   lease or expired lease. It applies a new lease on all returned items. This
    stored procedure is used to get all elements that are next to process for given state.
 
 More about stored procedures in CosmosDb: [stored procedures doc](https://docs.microsoft.com/en-us/rest/api/cosmos-db/stored-procedures).
-

--- a/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
+++ b/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
@@ -6,22 +6,17 @@ Cosmos DB stores for managing contract negotiations and data transfers use a lea
 
 ## Rationale
 
-If a connector fails after receiving a request, a process needs to be picked up by another connector instance. This is specially important
-when deploying to Kubernetes, since pods can be restarted at any time (e.g. VM autoscale). To ensure a resilient behavior a lease mechanism must be
-introduced in the transfer and contract negotiation processes.
+If a connector fails after receiving a request, a process needs to be picked up by another connector instance. This is specially important when deploying to Kubernetes, since pods can be restarted at any time (e.g. VM autoscale). To ensure a resilient behavior a lease mechanism must be introduced in the transfer and contract negotiation processes.
 
 ## Approach
 
 Cosmos document is extended with lease information: a lease holder, time when the lease was acquired and a lease duration.
 
-Lease acts as an exclusive lock: a party leasing a document owns an exclusive lock until the lease expires or it has been explicitly broken.
-Any attempt to acquire or break the lease on a document that has been leased by someone else results in an exception. Currently, the lease expiration time is hardcoded to 60 seconds.
+Lease acts as an exclusive lock: a party leasing a document owns an exclusive lock until the lease expires or it has been explicitly broken. Any attempt to acquire or break the lease on a document that has been leased by someone else results in an exception. Currently, the lease expiration time is hardcoded to 60 seconds.
 
 CosmosDb stores are using 2 stored procedures that handle the lease logic:
 
-1. [`lease.js`](/extensions/azure/cosmos/cosmos-common/src/main/resources/lease.js) - queries the database to look for an item and if an item is found
-   applies a lease on it. It's used to acquire the lock on single item in the
-   database before an update and to remove the lock after.
+1. [`lease.js`](/extensions/azure/cosmos/cosmos-common/src/main/resources/lease.js) - queries the database to look for an item and if an item is found applies a lease on it. It's used to acquire the lock on single item in the database before an update and to remove the lock after.
 
 ```java
    leaseContext.acquireLease(process.getId());
@@ -29,8 +24,6 @@ CosmosDb stores are using 2 stored procedures that handle the lease logic:
    leaseContext.breakLease(process.getId());
 ```
 
-1. [`nextForState.js`](/extensions/azure/cosmos/cosmos-common/src/main/resources/nextForState.js) - queries the database to look for all items that has no
-   lease or expired lease. It applies a new lease on all returned items. This
-   stored procedure is used to get batch of elements that are next to be processed for given state.
+1. [`nextForState.js`](/extensions/azure/cosmos/cosmos-common/src/main/resources/nextForState.js) - queries the database to look for all items that has no lease or expired lease. It applies a new lease on all returned items. This stored procedure is used to get batch of elements that are next to be processed for given state.
 
 More about stored procedures in CosmosDb: [stored procedures doc](https://docs.microsoft.com/rest/api/cosmos-db/stored-procedures).

--- a/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
+++ b/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
@@ -24,6 +24,6 @@ Cosmos DB stores are using 2 stored procedures that handle the lease logic:
    leaseContext.breakLease(process.getId());
 ```
 
-1. [`nextForState.js`](/extensions/azure/cosmos/cosmos-common/src/main/resources/nextForState.js) - queries the database to look for all items that has no lease or expired lease. It applies a new lease on all returned items. This stored procedure is used to get batch of elements that are next to be processed for given state.
+1. [`nextForState.js`](/extensions/azure/cosmos/cosmos-common/src/main/resources/nextForState.js) - queries the database to look for all items that has no lease or expired lease. It applies a new lease on all returned items. This stored procedure is used to get a batch of elements that are next to be processed for given state.
 
 More about stored procedures in Cosmos DB: [stored procedures doc](https://docs.microsoft.com/rest/api/cosmos-db/stored-procedures).

--- a/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
+++ b/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
@@ -12,16 +12,16 @@ introduced in the transfer and contract negotiation processes.
 
 ## Approach
 
-Cosmos document is extended with lease information: lease holder, time when the lease was acquired and a lease duration.
+Cosmos document is extended with lease information: a lease holder, time when the lease was acquired and a lease duration.
 
 Lease acts as an exclusive lock: a party leasing a document owns an exclusive lock until the lease expires or it has been explicitly broken.
 Any attempt to acquire or break the lease on a document that has been leased by someone else results in an exception.
 
-CosmosDb stores are using 2 stored procedures:
+CosmosDb stores are using 2 stored procedures that handle the lease logic:
 
 1. [`lease.js`](/extensions/azure/cosmos/cosmos-common/src/main/resources/lease.js) - queries the database to look for an item and if an item is found
    applies a lease on it. It's used to acquire the lock on single item in the
-   database during updating an item.
+   database before an update and to remove the lock after.
 
 ```java
    leaseContext.acquireLease(process.getId());

--- a/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
+++ b/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
@@ -33,4 +33,4 @@ CosmosDb stores are using 2 stored procedures that handle the lease logic:
    lease or expired lease. It applies a new lease on all returned items. This
    stored procedure is used to get all elements that are next to process for given state.
 
-More about stored procedures in CosmosDb: [stored procedures doc](https://docs.microsoft.com/en-us/rest/api/cosmos-db/stored-procedures).
+More about stored procedures in CosmosDb: [stored procedures doc](https://docs.microsoft.com/rest/api/cosmos-db/stored-procedures).

--- a/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
+++ b/docs/developer/decision-records/2022-03-30-cosmosdb-lease-mechanism/README.md
@@ -2,7 +2,7 @@
 
 ## Decision
 
-Cosmos DB stores for managing contract negotiations and data transfers should use a lease mechanism to control the processing of the items.
+Cosmos DB stores for managing contract negotiations and data transfers use a lease mechanism to control the processing of the items.
 
 ## Rationale
 


### PR DESCRIPTION
## What this PR changes/adds

ADR for CosmosDb lease mechanism with stored procedures.

## Why it does that

ADR to retroactively record architectural decision about the behaviour implemented in the Cosmos DB stored procedures.

## Further notes

## Linked Issue(s)

Together with PR #188 Closes #82 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
