### PR TITLE
Bug fix: Default value if the env var is null or blank

### DIFF
--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctions.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctions.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.dataspaceconnector.common.configuration;
 
+import org.eclipse.dataspaceconnector.common.string.StringUtils;
+
 /**
  * Common configuration functions used by extensions.
  */
@@ -25,7 +27,7 @@ public class ConfigurationFunctions {
      */
     public static String propOrEnv(String key, String defaultValue) {
         String value = System.getProperty(key);
-        if (value != null) {
+        if (!StringUtils.isNullOrBlank(value)) {
             return value;
         }
         String upperKey = key.toUpperCase().replace('.', '_');


### PR DESCRIPTION
## What this PR changes/adds

This PR modifies the propOrEnv method in ConfigurationFunctions class to use default value if property is null or blank instead of checking only if it's null.

## Why it does that

Environment variable or property shouldn't be blank, but rather unset if that's the case. 

## Further notes

This change will fix the failing Cosmos DB integration tests on EDC main branch.

## Linked Issue(s)

Closes #206 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
