### PR TITLE
Add concurrency to workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,10 @@ on:
       - '**.md'
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@ on:
       - 'docs/**'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/generate_openapi_spec.yaml
+++ b/.github/workflows/generate_openapi_spec.yaml
@@ -8,6 +8,10 @@ on:
       - '**.md'
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   GenerateOAS:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate_openapi_spec.yaml
+++ b/.github/workflows/generate_openapi_spec.yaml
@@ -9,7 +9,7 @@ on:
       - 'docs/**'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -8,6 +8,10 @@ on:
       - '**.md'
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   Azure-Storage-Integration-Test:

--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -9,7 +9,7 @@ on:
       - 'docs/**'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,10 +10,6 @@ on:
     types:
       - completed
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   Publish:
     # run only on upstream repo

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,6 +10,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Publish:
     # run only on upstream repo

--- a/.github/workflows/scan-pull-request.yaml
+++ b/.github/workflows/scan-pull-request.yaml
@@ -6,7 +6,7 @@ on:
     types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/scan-pull-request.yaml
+++ b/.github/workflows/scan-pull-request.yaml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
     types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-for-changelog-modifications:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -9,7 +9,7 @@ on:
       - 'docs/**'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -8,6 +8,10 @@ on:
       - '**.md'
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Unit-Test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What this PR changes/adds

Use concurrency to cancel in-progress runs of each workflow if new commits being pushed to PR. 

## Why it does that

Workflow related to previous/last commits keeps on executing and holds github runners and also utilize other cloud resource e.g. cosmos db for test etc. 

## Linked Issue(s)

#201

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
