### PR TITLE
Bug Fix - Check if the env var is null or blank

### DIFF
--- a/common/util/src/main/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctions.java
+++ b/common/util/src/main/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctions.java
@@ -32,7 +32,10 @@ public class ConfigurationFunctions {
         }
         String upperKey = key.toUpperCase().replace('.', '_');
         value = System.getenv(upperKey);
-        return value != null ? value : defaultValue;
+        if (!StringUtils.isNullOrBlank(value)) {
+            return value;
+        }
+        return defaultValue;
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR modifies the propOrEnv method in ConfigurationFunctions class to use default value if property is null or blank instead of checking only if it's null.

## Why it does that

Environment variable or property shouldn't be blank, but rather unset if that's the case. 

## Further notes

This change will fix the failing Cosmos DB integration tests on EDC main branch.

## Linked Issue(s)

Closes #206 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
