### PR TITLE
Add unit tests for ConfigurationFunctions

### DIFF
--- a/common/util/build.gradle.kts
+++ b/common/util/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     testFixturesImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testFixturesRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
     testFixturesImplementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
+    testImplementation("org.junit-pioneer:junit-pioneer:1.6.2")
 }
 
 publishing {

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
@@ -13,7 +13,7 @@
  */
 package org.eclipse.dataspaceconnector.common.configuration;
 
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -30,22 +30,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ConfigurationFunctionsTest {
 
     public static final String DEFAULT = "default";
-    public static final String VAR_1 = "VAR_1";
-    public static final String VAR_2 = "VAR_2";
-    public static final String VAR_3 = "VAR_3";
-    private static final String PROP_1 = "property1";
-    private static final String PROP_2 = "property2";
-    private static final String PROP_3 = "property3";
+    public static final String ENV_VAR_1 = "EDC_KEY1";
+    public static final String ENV_VAR_2 = "EDC_KEY2";
+    public static final String EDC_VAR_3 = "EDC_KEY3";
+    private static final String PROP_1 = "edc.key1";
+    private static final String PROP_2 = "edc.key2";
+    private static final String PROP_3 = "edc.key3";
     public static final String VALUE_1 = "value1";
 
-    @AfterAll
-    @ClearEnvironmentVariable(key = VAR_1)
-    @ClearEnvironmentVariable(key = VAR_2)
-    @ClearEnvironmentVariable(key = VAR_3)
+    @AfterEach
+    @ClearEnvironmentVariable(key = ENV_VAR_1)
+    @ClearEnvironmentVariable(key = ENV_VAR_2)
+    @ClearEnvironmentVariable(key = EDC_VAR_3)
     @ClearSystemProperty(key = PROP_1)
     @ClearSystemProperty(key = PROP_2)
     @ClearSystemProperty(key = PROP_3)
-    public static void cleanUp() {
+    public void cleanUp() {
         // clear env vars and system properties
     }
 
@@ -60,9 +60,9 @@ class ConfigurationFunctionsTest {
     }
 
     @ParameterizedTest
-    @SetEnvironmentVariable(key = VAR_1, value = VALUE_1)
-    @SetEnvironmentVariable(key = VAR_2, value = "")
-    @SetEnvironmentVariable(key = VAR_3, value = "    ")
+    @SetEnvironmentVariable(key = ENV_VAR_1, value = VALUE_1)
+    @SetEnvironmentVariable(key = ENV_VAR_2, value = "")
+    @SetEnvironmentVariable(key = EDC_VAR_3, value = "    ")
     @MethodSource("envVarsSource")
     public void returnEnv(String key, String expected) {
         String resultValue = ConfigurationFunctions.propOrEnv(key, DEFAULT);
@@ -85,10 +85,10 @@ class ConfigurationFunctionsTest {
 
     private static Stream<Arguments> envVarsSource() {
         return Stream.of(
-                Arguments.of(VAR_1, VALUE_1),
-                Arguments.of("var.1", VALUE_1),
-                Arguments.of(VAR_2, DEFAULT),
-                Arguments.of(VAR_3, DEFAULT)
+                Arguments.of(ENV_VAR_1, VALUE_1),
+                Arguments.of(PROP_1, VALUE_1),
+                Arguments.of(ENV_VAR_2, DEFAULT),
+                Arguments.of(EDC_VAR_3, DEFAULT)
         );
     }
 }

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
@@ -33,27 +33,27 @@ class ConfigurationFunctionsTest {
     public static final String ENV_VAR_1 = "EDC_KEY1";
     public static final String ENV_VAR_2 = "EDC_KEY2";
     public static final String EDC_VAR_3 = "EDC_KEY3";
-    private static final String PROP_1 = "edc.key1";
-    private static final String PROP_2 = "edc.key2";
-    private static final String PROP_3 = "edc.key3";
+    private static final String SYS_PROP_1 = "edc.key1";
+    private static final String SYS_PROP_2 = "edc.key2";
+    private static final String SYS_PROP_3 = "edc.key3";
     public static final String VALUE_1 = "value1";
 
     @AfterEach
     @ClearEnvironmentVariable(key = ENV_VAR_1)
     @ClearEnvironmentVariable(key = ENV_VAR_2)
     @ClearEnvironmentVariable(key = EDC_VAR_3)
-    @ClearSystemProperty(key = PROP_1)
-    @ClearSystemProperty(key = PROP_2)
-    @ClearSystemProperty(key = PROP_3)
+    @ClearSystemProperty(key = SYS_PROP_1)
+    @ClearSystemProperty(key = SYS_PROP_2)
+    @ClearSystemProperty(key = SYS_PROP_3)
     public void cleanUp() {
         // clear env vars and system properties
     }
 
     @ParameterizedTest
     @MethodSource("propertiesSource")
-    @SetSystemProperty(key = PROP_1, value = VALUE_1)
-    @SetSystemProperty(key = PROP_2, value = "")
-    @SetSystemProperty(key = PROP_3, value = "    ")
+    @SetSystemProperty(key = SYS_PROP_1, value = VALUE_1)
+    @SetSystemProperty(key = SYS_PROP_2, value = "")
+    @SetSystemProperty(key = SYS_PROP_3, value = "    ")
     public void returnSystemProperty(String key, String expected) {
         String resultValue = ConfigurationFunctions.propOrEnv(key, DEFAULT);
         assertThat(resultValue).isEqualTo(expected);
@@ -77,16 +77,16 @@ class ConfigurationFunctionsTest {
 
     private static Stream<Arguments> propertiesSource() {
         return Stream.of(
-                Arguments.of(PROP_1, VALUE_1),
-                Arguments.of(PROP_2, DEFAULT),
-                Arguments.of(PROP_3, DEFAULT)
+                Arguments.of(SYS_PROP_1, VALUE_1),
+                Arguments.of(SYS_PROP_2, DEFAULT),
+                Arguments.of(SYS_PROP_3, DEFAULT)
         );
     }
 
     private static Stream<Arguments> envVarsSource() {
         return Stream.of(
                 Arguments.of(ENV_VAR_1, VALUE_1),
-                Arguments.of(PROP_1, VALUE_1),
+                Arguments.of(SYS_PROP_1, VALUE_1),
                 Arguments.of(ENV_VAR_2, DEFAULT),
                 Arguments.of(EDC_VAR_3, DEFAULT)
         );

--- a/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
+++ b/common/util/src/test/java/org/eclipse/dataspaceconnector/common/configuration/ConfigurationFunctionsTest.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.common.configuration;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junitpioneer.jupiter.ClearEnvironmentVariable;
+import org.junitpioneer.jupiter.ClearSystemProperty;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.junitpioneer.jupiter.SetSystemProperty;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigurationFunctionsTest {
+
+    public static final String DEFAULT = "default";
+    public static final String VAR_1 = "VAR_1";
+    public static final String VAR_2 = "VAR_2";
+    public static final String VAR_3 = "VAR_3";
+    private static final String PROP_1 = "property1";
+    private static final String PROP_2 = "property2";
+    private static final String PROP_3 = "property3";
+    public static final String VALUE_1 = "value1";
+
+    @AfterAll
+    @ClearEnvironmentVariable(key = VAR_1)
+    @ClearEnvironmentVariable(key = VAR_2)
+    @ClearEnvironmentVariable(key = VAR_3)
+    @ClearSystemProperty(key = PROP_1)
+    @ClearSystemProperty(key = PROP_2)
+    @ClearSystemProperty(key = PROP_3)
+    public static void cleanUp() {
+        // clear env vars and system properties
+    }
+
+    @ParameterizedTest
+    @MethodSource("propertiesSource")
+    @SetSystemProperty(key = PROP_1, value = VALUE_1)
+    @SetSystemProperty(key = PROP_2, value = "")
+    @SetSystemProperty(key = PROP_3, value = "    ")
+    public void returnSystemProperty(String key, String expected) {
+        String resultValue = ConfigurationFunctions.propOrEnv(key, DEFAULT);
+        assertThat(resultValue).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @SetEnvironmentVariable(key = VAR_1, value = VALUE_1)
+    @SetEnvironmentVariable(key = VAR_2, value = "")
+    @SetEnvironmentVariable(key = VAR_3, value = "    ")
+    @MethodSource("envVarsSource")
+    public void returnEnv(String key, String expected) {
+        String resultValue = ConfigurationFunctions.propOrEnv(key, DEFAULT);
+        assertThat(resultValue).isEqualTo(expected);
+    }
+
+    @Test
+    public void returnDefaultEnv_NullValue() {
+        String resultValue = ConfigurationFunctions.propOrEnv("nonexistent", DEFAULT);
+        assertThat(resultValue).isEqualTo(DEFAULT);
+    }
+
+    private static Stream<Arguments> propertiesSource() {
+        return Stream.of(
+                Arguments.of(PROP_1, VALUE_1),
+                Arguments.of(PROP_2, DEFAULT),
+                Arguments.of(PROP_3, DEFAULT)
+        );
+    }
+
+    private static Stream<Arguments> envVarsSource() {
+        return Stream.of(
+                Arguments.of(VAR_1, VALUE_1),
+                Arguments.of("var.1", VALUE_1),
+                Arguments.of(VAR_2, DEFAULT),
+                Arguments.of(VAR_3, DEFAULT)
+        );
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Unit tests to ConfigurationFunctions.

## Why it does that

It's an addition to the bug fix: https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/pull/1069
It came up as a feedback in the PR.

## Further notes

It uses https://junit-pioneer.org/docs/environment-variables/ library to set environment variables in unit tests.

## Linked Issue(s)

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
