### PR TITLE
DataManagement API: TransferProcessApiController implementation

### DIFF
--- a/extensions/api/data-management/transferprocess/build.gradle.kts
+++ b/extensions/api/data-management/transferprocess/build.gradle.kts
@@ -16,6 +16,7 @@
 val infoModelVersion: String by project
 val rsApi: String by project
 val jerseyVersion: String by project
+val restAssured: String by project
 
 plugins {
     `java-library`
@@ -30,9 +31,14 @@ dependencies {
     implementation(project(":extensions:api:data-management:api-configuration"))
     implementation(project(":extensions:transaction:transaction-spi"))
 
+    testImplementation(project(":extensions:in-memory:transfer-store-memory"))
+    testImplementation(project(":core:transfer"))
+    testImplementation(project(":spi:core-spi"))
     testImplementation(project(":extensions:http"))
+    testImplementation(project(":extensions:in-memory:assetindex-memory"))
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation(testFixtures(project(":common:util")))
+    testImplementation("io.rest-assured:rest-assured:${restAssured}")
 }
 
 publishing {

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApi.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApi.java
@@ -34,5 +34,5 @@ public interface TransferProcessApi {
 
     void deprovisionTransferProcess(String id);
 
-    String initiateTransfer(String assetId, TransferRequestDto transferRequest);
+    String initiateTransfer(TransferRequestDto transferRequest);
 }

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiController.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiController.java
@@ -35,7 +35,9 @@ import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
+import org.eclipse.dataspaceconnector.spi.result.AbstractResult;
 import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 
 import java.util.List;
@@ -106,18 +108,28 @@ public class TransferProcessApiController implements TransferProcessApi {
     }
 
     @POST
-    @Path("/{id}/request")
+    @Path("/request")
     @Override
-    public String initiateTransfer(@PathParam("id") String assetId, TransferRequestDto transferRequest) {
-        if (StringUtils.isNullOrBlank(assetId)) {
-            throw new IllegalArgumentException("Asset ID not valid");
-        }
-
+    public String initiateTransfer(TransferRequestDto transferRequest) {
         if (!isValid(transferRequest)) {
             throw new IllegalArgumentException("Transfer request body not valid");
         }
-        monitor.debug("Starting transfer for asset " + assetId + "to " + transferRequest.getDataDestination());
-        return "not-implemented"; //will be the transfer process id
+        var dataRequest = Optional.ofNullable(transformerRegistry.transform(transferRequest, DataRequest.class))
+                .filter(AbstractResult::succeeded).map(AbstractResult::getContent);
+        if (dataRequest.isEmpty()) {
+            throw  new IllegalArgumentException("Error during transforming TransferRequestDto into DataRequest");
+        }
+        monitor.debug("Starting transfer for asset " + transferRequest.getAssetId());
+
+        ServiceResult<String> result = service.initiateTransfer(dataRequest.get());
+        if (result.succeeded()) {
+            monitor.debug(format("Transfer process initialised %s", result.getContent()));
+            return result.getContent();
+        } else {
+            String message = format("Error during initiating the transfer with assetId: %s", transferRequest.getAssetId());
+            monitor.severe(message);
+            throw new EdcException(message);
+        }
     }
 
     @POST
@@ -147,7 +159,8 @@ public class TransferProcessApiController implements TransferProcessApi {
     }
 
     private boolean isValid(TransferRequestDto transferRequest) {
-        return !StringUtils.isNullOrBlank(transferRequest.getConnectorAddress()) &&
+        return !StringUtils.isNullOrBlank(transferRequest.getAssetId()) &&
+                !StringUtils.isNullOrBlank(transferRequest.getConnectorAddress()) &&
                 !StringUtils.isNullOrBlank(transferRequest.getContractId()) &&
                 !StringUtils.isNullOrBlank(transferRequest.getProtocol()) &&
                 transferRequest.getDataDestination() != null;

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiController.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiController.java
@@ -25,13 +25,22 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.service.TransferProcessService;
+import org.eclipse.dataspaceconnector.api.exception.ObjectExistsException;
+import org.eclipse.dataspaceconnector.api.exception.ObjectNotFoundException;
+import org.eclipse.dataspaceconnector.api.result.ServiceResult;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
 import org.eclipse.dataspaceconnector.common.string.StringUtils;
+import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
+import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
@@ -40,9 +49,13 @@ import static java.lang.String.format;
 @Path("/transferprocess")
 public class TransferProcessApiController implements TransferProcessApi {
     private final Monitor monitor;
+    private final TransferProcessService service;
+    private final DtoTransformerRegistry transformerRegistry;
 
-    public TransferProcessApiController(Monitor monitor) {
+    public TransferProcessApiController(Monitor monitor, TransferProcessService service, DtoTransformerRegistry transformerRegistry) {
         this.monitor = monitor;
+        this.service = service;
+        this.transformerRegistry = transformerRegistry;
     }
 
     @GET
@@ -58,34 +71,44 @@ public class TransferProcessApiController implements TransferProcessApi {
                 .sortField(sortField)
                 .filter(filterExpression)
                 .sortOrder(sortOrder).build();
-        monitor.debug(format("get all TransferProcesses %s", spec));
+        monitor.debug(format("Get all TransferProcesses %s", spec));
 
-        return Collections.emptyList();
-
+        return service.query(spec).stream()
+                .map(tp -> transformerRegistry.transform(tp, TransferProcessDto.class))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .collect(Collectors.toList());
     }
 
     @GET
-    @Path("{id}")
+    @Path("/{id}")
     @Override
     public TransferProcessDto getTransferProcess(@PathParam("id") String id) {
-        monitor.debug(format("get TransferProcess with ID %s", id));
+        monitor.debug(format("Get TransferProcess with ID %s", id));
 
-        return null;
+        return Optional.of(id)
+                .map(service::findById)
+                .map(it -> transformerRegistry.transform(it, TransferProcessDto.class))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .orElseThrow(() -> new ObjectNotFoundException(TransferProcess.class, id));
     }
 
     @GET
-    @Path("{id}/state")
+    @Path("/{id}/state")
     @Override
     public String getTransferProcessState(@PathParam("id") String id) {
-        monitor.debug(format("get TransferProcess State with ID %s", id));
+        monitor.debug(format("Get TransferProcess State with ID %s", id));
 
-        return "";
+        return Optional.of(id)
+                .map(service::getState)
+                .orElseThrow(() -> new ObjectNotFoundException(TransferProcess.class, id));
     }
 
     @POST
+    @Path("/{id}/request")
     @Override
     public String initiateTransfer(@PathParam("id") String assetId, TransferRequestDto transferRequest) {
-
         if (StringUtils.isNullOrBlank(assetId)) {
             throw new IllegalArgumentException("Asset ID not valid");
         }
@@ -98,17 +121,29 @@ public class TransferProcessApiController implements TransferProcessApi {
     }
 
     @POST
-    @Path("{id}/cancel")
+    @Path("/{id}/cancel")
     @Override
     public void cancelTransferProcess(@PathParam("id") String id) {
         monitor.debug("Cancelling TransferProcess with ID " + id);
+        var result = service.cancel(id);
+        if (result.succeeded()) {
+            monitor.debug(format("Transfer process canceled %s", result.getContent().getId()));
+        } else {
+            handleFailedResult(result, id);
+        }
     }
 
     @POST
-    @Path("{id}/deprovision")
+    @Path("/{id}/deprovision")
     @Override
     public void deprovisionTransferProcess(@PathParam("id") String id) {
         monitor.debug(format("Attempting to deprovision TransferProcess with id %s", id));
+        var result = service.deprovision(id);
+        if (result.succeeded()) {
+            monitor.debug(format("Transfer process deprovisioned %s", result.getContent().getId()));
+        } else {
+            handleFailedResult(result, id);
+        }
     }
 
     private boolean isValid(TransferRequestDto transferRequest) {
@@ -116,5 +151,13 @@ public class TransferProcessApiController implements TransferProcessApi {
                 !StringUtils.isNullOrBlank(transferRequest.getContractId()) &&
                 !StringUtils.isNullOrBlank(transferRequest.getProtocol()) &&
                 transferRequest.getDataDestination() != null;
+    }
+
+    private void handleFailedResult(ServiceResult<TransferProcess> result, String id) {
+        switch (result.reason()) {
+            case NOT_FOUND: throw new ObjectNotFoundException(TransferProcess.class, id);
+            case CONFLICT: throw new ObjectExistsException(TransferProcess.class, id);
+            default: throw new EdcException("unexpected error");
+        }
     }
 }

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtension.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.dataspaceconnector.api.datamanagement.configuration.DataManag
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.service.TransferProcessServiceImpl;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform.DataRequestToDataRequestDtoTransformer;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform.TransferProcessToTransferProcessDtoTransformer;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform.TransferRequestDtoToDataRequestTransformer;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
@@ -62,5 +63,6 @@ public class TransferProcessApiExtension implements ServiceExtension {
 
         transformerRegistry.register(new DataRequestToDataRequestDtoTransformer());
         transformerRegistry.register(new TransferProcessToTransferProcessDtoTransformer());
+        transformerRegistry.register(new TransferRequestDtoToDataRequestTransformer());
     }
 }

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtension.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 
 import org.eclipse.dataspaceconnector.api.datamanagement.configuration.DataManagementApiConfiguration;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.service.TransferProcessServiceImpl;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform.DataRequestToDataRequestDtoTransformer;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform.TransferProcessToTransferProcessDtoTransformer;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
@@ -22,6 +23,12 @@ import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
+import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+
+import static java.util.Optional.ofNullable;
 
 public class TransferProcessApiExtension implements ServiceExtension {
     @Inject
@@ -33,9 +40,25 @@ public class TransferProcessApiExtension implements ServiceExtension {
     @Inject
     private DtoTransformerRegistry transformerRegistry;
 
+    @Inject
+    private TransferProcessStore transferProcessStore;
+
+    @Inject
+    private TransferProcessManager manager;
+
+    @Inject(required = false)
+    TransactionContext transactionContext;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
-        webService.registerResource(configuration.getContextAlias(), new TransferProcessApiController(context.getMonitor()));
+        var monitor = context.getMonitor();
+        var transactionContextImpl = ofNullable(transactionContext)
+                .orElseGet(() -> {
+                    monitor.warning("No TransactionContext registered, a no-op implementation will be used, not suitable for production environments");
+                    return new NoopTransactionContext();
+                });
+        webService.registerResource(configuration.getContextAlias(), new TransferProcessApiController(context.getMonitor(),
+                new TransferProcessServiceImpl(transferProcessStore, manager, transactionContextImpl), transformerRegistry));
 
         transformerRegistry.register(new DataRequestToDataRequestDtoTransformer());
         transformerRegistry.register(new TransferProcessToTransferProcessDtoTransformer());

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferRequestDto.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferRequestDto.java
@@ -34,6 +34,7 @@ public class TransferRequestDto {
     private TransferType transferType;
     private String protocol = "ids-multipart";
     private String connectorId;
+    private String assetId;
 
     public String getConnectorAddress() {
         return connectorAddress;
@@ -65,6 +66,10 @@ public class TransferRequestDto {
 
     public String getConnectorId() {
         return connectorId;
+    }
+
+    public String getAssetId() {
+        return assetId;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -117,6 +122,11 @@ public class TransferRequestDto {
 
         public Builder connectorId(String connectorId) {
             request.connectorId = connectorId;
+            return this;
+        }
+
+        public Builder assetId(String assetId) {
+            request.assetId = assetId;
             return this;
         }
 

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessService.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessService.java
@@ -14,9 +14,12 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.service;
 
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
 import org.eclipse.dataspaceconnector.api.result.ServiceResult;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -76,4 +79,13 @@ public interface TransferProcessService {
      */
     @NotNull
     ServiceResult<TransferProcess> deprovision(String transferProcessId);
+
+    /**
+     * Initiate transfer request.
+     *
+     * @param request for the transfer.
+     * @return a result that is successful if the transfer process was initiated with id of created transferProcess.
+     */
+    @NotNull
+    ServiceResult<String> initiateTransfer(DataRequest request);
 }

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessService.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessService.java
@@ -14,11 +14,8 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.service;
 
-import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
-import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
 import org.eclipse.dataspaceconnector.api.result.ServiceResult;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
-import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.jetbrains.annotations.NotNull;

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessService.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessService.java
@@ -64,7 +64,7 @@ public interface TransferProcessService {
      * @return a result that is successful if the transfer process was found and is in a state that can be canceled
      */
     @NotNull
-    ServiceResult<?> cancel(String transferProcessId);
+    ServiceResult<TransferProcess> cancel(String transferProcessId);
 
     /**
      * Asynchronously requests deprovisioning of the transfer process.
@@ -75,5 +75,5 @@ public interface TransferProcessService {
      * @return a result that is successful if the transfer process was found and is in a state that can be deprovisioned
      */
     @NotNull
-    ServiceResult<?> deprovision(String transferProcessId);
+    ServiceResult<TransferProcess> deprovision(String transferProcessId);
 }

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferRequestDtoToDataRequestTransformer.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferRequestDtoToDataRequestTransformer.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
+
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformer;
+import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+public class TransferRequestDtoToDataRequestTransformer implements DtoTransformer<TransferRequestDto, DataRequest> {
+
+    @Override
+    public Class<TransferRequestDto> getInputType() {
+        return TransferRequestDto.class;
+    }
+
+    @Override
+    public Class<DataRequest> getOutputType() {
+        return DataRequest.class;
+    }
+
+    @Override
+    public @Nullable DataRequest transform(@Nullable TransferRequestDto object, @NotNull TransformerContext context) {
+        Objects.requireNonNull(context);
+        if (object == null) {
+            return null;
+        }
+        return DataRequest.Builder.newInstance()
+                .assetId(object.getAssetId())
+                .connectorId(object.getConnectorId())
+                .dataDestination(object.getDataDestination())
+                .connectorAddress(object.getConnectorAddress())
+                .contractId(object.getContractId())
+                .transferType(object.getTransferType())
+                .destinationType(object.getDataDestination().getType())
+                .properties(object.getProperties())
+                .managedResources(object.isManagedResources())
+                .protocol(object.getProtocol())
+                .dataDestination(object.getDataDestination())
+                .build();
+    }
+}

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
@@ -15,8 +15,10 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 
 import io.restassured.specification.RequestSpecification;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.junit.jupiter.api.BeforeEach;
@@ -197,6 +199,42 @@ class TransferProcessApiControllerIntegrationTest {
                 .post("/transferprocess/" + PROCESS_ID + "/deprovision")
                 .then()
                 .statusCode(409);
+    }
+
+    @Test
+    void initiateRequest(TransferProcessStore store) {
+        var request = TransferRequestDto.Builder.newInstance()
+                .connectorAddress("http://some-contract")
+                .contractId("some-contract")
+                .protocol("test-asset")
+                .assetId("assetId")
+                .dataDestination(DataAddress.Builder.newInstance().type("test-type").build())
+                .connectorId("connectorId")
+                .properties(Map.of("prop", "value"))
+                .build();
+
+        var result = baseRequest()
+                .contentType(JSON)
+                .body(request)
+                .post("/transferprocess/request")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        assertThat(result).isNotBlank();
+    }
+
+    @Test
+    void initiateRequest_badRequest() {
+
+        baseRequest()
+                .contentType(JSON)
+                .body("bad-request")
+                .post("/transferprocess/request")
+                .then()
+                .statusCode(400)
+                .extract().body().asString();
+
     }
 
     private TransferProcess createTransferProcess(String processId) {

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
@@ -183,7 +183,7 @@ class TransferProcessApiControllerIntegrationTest {
     }
 
     @Test
-    void deprovision__notFound() {
+    void deprovision_notFound() {
         baseRequest()
                 .contentType(JSON)
                 .post("/transferprocess/nonExistingId/deprovision")
@@ -192,7 +192,7 @@ class TransferProcessApiControllerIntegrationTest {
     }
 
     @Test
-    void deprovision__conflict(TransferProcessStore store) {
+    void deprovision_conflict(TransferProcessStore store) {
         store.create(createTransferProcess(PROCESS_ID, INITIAL.code()));
         baseRequest()
                 .contentType(JSON)

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
@@ -14,90 +14,208 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-import org.eclipse.dataspaceconnector.common.testfixtures.TestUtils;
-import org.eclipse.dataspaceconnector.extension.jersey.CorsFilterConfiguration;
-import org.eclipse.dataspaceconnector.extension.jersey.JerseyRestService;
-import org.eclipse.dataspaceconnector.extension.jetty.JettyConfiguration;
-import org.eclipse.dataspaceconnector.extension.jetty.JettyService;
-import org.eclipse.dataspaceconnector.extension.jetty.PortMapping;
-import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.types.TypeManager;
-import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.BeforeAll;
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
+import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.io.IOException;
+import java.util.Map;
 
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
-import static org.mockito.Mockito.mock;
+import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.getFreePort;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.COMPLETED;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.INITIAL;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.IN_PROGRESS;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.PROVISIONING;
+import static org.hamcrest.Matchers.is;
 
+@ExtendWith(EdcExtension.class)
 class TransferProcessApiControllerIntegrationTest {
 
-    private static int port;
-    private OkHttpClient client;
-
-    @BeforeAll
-    static void prepareWebserver() {
-        port = TestUtils.getFreePort();
-        var monitor = mock(Monitor.class);
-        var config = new JettyConfiguration(null, null);
-        config.portMapping(new PortMapping("data", port, "/api/v1/data"));
-        var jetty = new JettyService(config, monitor);
-
-        var ctrl = new TransferProcessApiController(monitor);
-        var jerseyService = new JerseyRestService(jetty, new TypeManager(), mock(CorsFilterConfiguration.class), monitor);
-        jetty.start();
-        jerseyService.registerResource("data", ctrl);
-        jerseyService.start();
-    }
+    public static final String PROCESS_ID = "processId";
+    private final int port = getFreePort();
+    private final String authKey = "123456";
 
     @BeforeEach
-    void setup() {
-        client = testOkHttpClient();
+    void setUp(EdcExtension extension) {
+        extension.setConfiguration(Map.of(
+                "web.http.data.port", String.valueOf(port),
+                "web.http.data.path", "/api/v1/data",
+                "edc.api.auth.key", authKey
+        ));
     }
 
     @Test
-    void getAllTransferProcesses() throws IOException {
-        var response = get(basePath());
-        assertThat(response.code()).isEqualTo(200);
+    void getAllTransferProcesses(TransferProcessStore store) {
+        store.create(createTransferProcess(PROCESS_ID));
+
+        baseRequest()
+                .get("/transferprocess")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(1));
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port)
+                .basePath("/api/v1/data")
+                .header("x-api-key", authKey)
+                .when();
     }
 
     @Test
-    void getTransferProcesses_withPaging() throws IOException {
-        try (var response = get(basePath() + "?offset=10&limit=15&sort=ASC")) {
-            assertThat(response.code()).isEqualTo(200);
-        }
+    void getTransferProcesses_withLimit(TransferProcessStore store) {
+        store.create(createTransferProcess("processId_1"));
+        store.create(createTransferProcess("processId_2"));
+
+        baseRequest()
+                .get("/transferprocess?offset=0&limit=15")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(2));
     }
 
     @Test
-    void getSingleTransferProcess() throws IOException {
-        var id = "test-id";
-        try (var response = get(basePath() + "/" + id)) {
-            //assertThat(response.code()).isEqualTo(200);
-        }
+    void getTransferProcesses_withLimitAndOffset(TransferProcessStore store) {
+        store.create(createTransferProcess("processId_1"));
+        store.create(createTransferProcess("processId_2"));
+
+        baseRequest()
+                .get("/transferprocess?offset=1&limit=1")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(1));
+    }
+
+    @Test
+    void getSingleTransferProcess(TransferProcessStore store) {
+        store.create(createTransferProcess(PROCESS_ID));
+        baseRequest()
+                .get("/transferprocess/" + PROCESS_ID)
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("id", is(PROCESS_ID));
 
     }
 
     @Test
-    void getSingleTransferProcess_notFound() throws IOException {
-        try (var response = get(basePath() + "/not-exist")) {
-            // assertThat(response.code()).isEqualTo(404);
-        }
+    void getSingletransferProcess_notFound() {
+        baseRequest()
+                .get("/transferprocess/nonExistingId")
+                .then()
+                .statusCode(404);
     }
 
+    @Test
+    void getSingleTransferProcessState(TransferProcessStore store) {
+        store.create(createTransferProcess(PROCESS_ID, PROVISIONING.code()));
 
-    @NotNull
-    private String basePath() {
-        return "http://localhost:" + port + "/api/v1/data/transferprocess";
+        var state = baseRequest()
+                .get("/transferprocess/" + PROCESS_ID + "/state")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().asString();
+
+        assertThat(state).isEqualTo("PROVISIONING");
     }
 
-    @NotNull
-    private Response get(String url) throws IOException {
-        return client.newCall(new Request.Builder().get().url(url).build()).execute();
+    @Test
+    void getSingletransferProcessState_notFound() {
+        baseRequest()
+                .get("/transferprocess/nonExistingId/state")
+                .then()
+                .statusCode(404);
     }
+
+    @Test
+    void cancel(TransferProcessStore store) {
+        store.create(createTransferProcess(PROCESS_ID, IN_PROGRESS.code()));
+
+        baseRequest()
+                .contentType(JSON)
+                .post("/transferprocess/" + PROCESS_ID + "/cancel")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    void cancel_notFound() {
+        baseRequest()
+                .contentType(JSON)
+                .post("/transferprocess/nonExistingId/cancel")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void cancel_conflict(TransferProcessStore store) {
+        store.create(createTransferProcess(PROCESS_ID, COMPLETED.code()));
+        baseRequest()
+                .contentType(JSON)
+                .post("/transferprocess/" + PROCESS_ID + "/cancel")
+                .then()
+                .statusCode(409);
+    }
+
+    @Test
+    void deprovision(TransferProcessStore store) {
+        store.create(createTransferProcess(PROCESS_ID, COMPLETED.code()));
+
+        baseRequest()
+                .contentType(JSON)
+                .post("/transferprocess/" + PROCESS_ID + "/deprovision")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    void deprovision__notFound() {
+        baseRequest()
+                .contentType(JSON)
+                .post("/transferprocess/nonExistingId/deprovision")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void deprovision__conflict(TransferProcessStore store) {
+        store.create(createTransferProcess(PROCESS_ID, INITIAL.code()));
+        baseRequest()
+                .contentType(JSON)
+                .post("/transferprocess/" + PROCESS_ID + "/deprovision")
+                .then()
+                .statusCode(409);
+    }
+
+    private TransferProcess createTransferProcess(String processId) {
+        return createTransferProcessBuilder()
+                .id(processId)
+                .dataRequest(DataRequest.Builder.newInstance().destinationType("file").build())
+                .build();
+    }
+
+    private TransferProcess createTransferProcess(String processId, int state) {
+        return createTransferProcessBuilder()
+                .id(processId)
+                .state(state)
+                .dataRequest(DataRequest.Builder.newInstance().destinationType("file").build())
+                .build();
+    }
+
+    private TransferProcess.Builder createTransferProcessBuilder() {
+        return TransferProcess.Builder.newInstance();
+    }
+
 }

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerTest.java
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class TransferProcessApiApiControllerTest {
+class TransferProcessApiControllerTest {
     public static final int OFFSET = 5;
     public static final int LIMIT = 10;
     private final TransferProcessService service = mock(TransferProcessService.class);
@@ -82,7 +82,7 @@ class TransferProcessApiApiControllerTest {
     }
 
     @Test
-    void getAll_getAll_filtersOutFailedTransforms() {
+    void getAll_filtersOutFailedTransforms() {
         TransferProcess transferProcess = transferProcess();
 
         when(transformerRegistry.transform(isA(TransferProcess.class), eq(TransferProcessDto.class))).thenReturn(Result.failure("failure"));

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtensionTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtensionTest.java
@@ -24,6 +24,8 @@ import org.eclipse.dataspaceconnector.junit.launcher.DependencyInjectionExtensio
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.system.injection.ObjectFactory;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
+import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -47,6 +49,8 @@ class TransferProcessApiExtensionTest {
         context.registerService(WebService.class, webServiceMock);
         var mockConfiguration = new DataManagementApiConfiguration(contextAlias);
         context.registerService(DataManagementApiConfiguration.class, mockConfiguration);
+        context.registerService(TransferProcessManager.class, mock(TransferProcessManager.class));
+        context.registerService(TransferProcessStore.class, mock(TransferProcessStore.class));
 
         var extension = factory.constructInstance(TransferProcessApiExtension.class);
         extension.initialize(context);

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImplTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImplTest.java
@@ -15,11 +15,14 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.service;
 
 import com.github.javafaker.Faker;
+import org.eclipse.dataspaceconnector.api.result.ServiceResult;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResult;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.CancelTransferCommand;
@@ -134,6 +137,17 @@ class TransferProcessServiceImplTest {
 
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureMessages()).containsExactly("TransferProcess " + id + " does not exist");
+    }
+
+    @Test
+    void initiateTransfer() {
+        var dataRequest = DataRequest.Builder.newInstance().destinationType("type").build();
+        String processId = "processId";
+
+        when(manager.initiateConsumerRequest(dataRequest)).thenReturn(TransferInitiateResult.success(processId));
+        ServiceResult<String> result = service.initiateTransfer(dataRequest);
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).isEqualTo(processId);
     }
 
     public static List<TransferProcessStates> cancellableStates() {

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferRequestDtoToDataRequestTransformerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferRequestDtoToDataRequestTransformerTest.java
@@ -1,0 +1,60 @@
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
+
+import com.github.javafaker.Faker;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformer;
+import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class TransferRequestDtoToDataRequestTransformerTest {
+
+    private static Faker faker = new Faker();
+    private DtoTransformer<TransferRequestDto, DataRequest> transformer = new TransferRequestDtoToDataRequestTransformer();
+
+    @Test
+    void getInputType() {
+        assertThat(transformer.getInputType()).isEqualTo(TransferRequestDto.class);
+    }
+
+    @Test
+    void getOutputType() {
+        assertThat(transformer.getOutputType()).isEqualTo(DataRequest.class);
+    }
+
+    @Test
+    void transform() {
+        var context = mock(TransformerContext.class);
+        var transferReq = transferRequestDto();
+        var dataRequest = transformer.transform(transferReq, context);
+        assertThat(dataRequest.getAssetId()).isEqualTo(transferReq.getAssetId());
+        assertThat(dataRequest.getConnectorAddress()).isEqualTo(transferReq.getConnectorAddress());
+        assertThat(dataRequest.getConnectorId()).isEqualTo(transferReq.getConnectorId());
+        assertThat(dataRequest.getDataDestination()).isEqualTo(transferReq.getDataDestination());
+        assertThat(dataRequest.getDestinationType()).isEqualTo(transferReq.getDataDestination().getType());
+        assertThat(dataRequest.getContractId()).isEqualTo(transferReq.getContractId());
+        assertThat(dataRequest.getProtocol()).isEqualTo(transferReq.getProtocol());
+        assertThat(dataRequest.getProperties()).isEqualTo(transferReq.getProperties());
+        assertThat(dataRequest.getTransferType()).isEqualTo(transferReq.getTransferType());
+        assertThat(dataRequest.isManagedResources()).isEqualTo(transferReq.isManagedResources());
+    }
+
+    private TransferRequestDto transferRequestDto() {
+        return TransferRequestDto.Builder.newInstance()
+                .connectorAddress(faker.internet().url())
+                .assetId(faker.lorem().word())
+                .contractId(faker.lorem().word())
+                .protocol(faker.lorem().word())
+                .dataDestination(DataAddress.Builder.newInstance().type(faker.lorem().word()).build())
+                .connectorId(faker.lorem().word())
+                .properties(Map.of(faker.lorem().word(), faker.lorem().word()))
+                .build();
+    }
+
+}

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -9,71 +9,100 @@ info:
 servers:
 - url: /
 paths:
-  /identity-hub/query-commits:
+  /catalog:
     post:
-      operationId: queryCommits
+      operationId: getCatalog
       requestBody:
         content:
           application/json:
             schema:
-              type: string
+              $ref: '#/components/schemas/FederatedCatalogCacheQuery'
       responses:
         default:
           description: default response
           content:
             application/json:
               schema:
-                type: string
-  /identity-hub/query-objects:
-    post:
-      operationId: queryObjects
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractOffer'
+  /instances:
+    get:
+      operationId: getAll
       responses:
         default:
           description: default response
           content:
             application/json:
               schema:
-                type: string
-  /identity-hub/collections:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataPlaneInstance'
     post:
-      operationId: write
+      operationId: addEntry
       requestBody:
         content:
           application/json:
             schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /identity-hub/collections-commit:
-    post:
-      operationId: writeCommit
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties:
-                type: string
+              $ref: '#/components/schemas/DataPlaneInstance'
       responses:
         default:
           description: default response
           content:
             application/json: {}
-  /control/catalog:
+  /instances/select:
+    post:
+      operationId: find
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SelectionRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataPlaneInstance'
+  /policies:
     get:
-      operationId: getDescription
+      operationId: getAllPolicies
       parameters:
-      - name: provider
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
         in: query
         required: false
         style: form
@@ -84,23 +113,43 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
-  /control/transfer:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PolicyDefinitionDto'
     post:
-      operationId: addTransfer
+      operationId: createPolicy
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DataRequest'
+              $ref: '#/components/schemas/PolicyDefinitionDto'
       responses:
         default:
           description: default response
           content:
             application/json: {}
-  /control/agreement/{id}:
+  /policies/{id}:
     get:
-      operationId: getAgreementById
+      operationId: getPolicy
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDefinitionDto'
+    delete:
+      operationId: deletePolicy
       parameters:
       - name: id
         in: path
@@ -114,46 +163,33 @@ paths:
           description: default response
           content:
             application/json: {}
-  /control/negotiation/{id}:
+  /check/health:
     get:
-      operationId: getNegotiationById
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+      operationId: checkHealth
       responses:
         default:
           description: default response
           content:
             application/json: {}
-  /control/negotiation/{id}/state:
+  /check/liveness:
     get:
-      operationId: getNegotiationStateById
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+      operationId: getLiveness
       responses:
         default:
           description: default response
           content:
             application/json: {}
-  /control/negotiation:
-    post:
-      operationId: initiateNegotiation
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ContractOfferRequest'
+  /check/readiness:
+    get:
+      operationId: getReadiness
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /check/startup:
+    get:
+      operationId: getStartup
       responses:
         default:
           description: default response
@@ -312,9 +348,82 @@ paths:
             application/json:
               schema:
                 type: string
-  /instances:
+  /transferprocess/{id}/cancel:
+    post:
+      operationId: cancelTransferProcess
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /transferprocess/{id}/deprovision:
+    post:
+      operationId: deprovisionTransferProcess
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /transferprocess:
     get:
-      operationId: getAll
+      operationId: getAllTransferProcesses
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
       responses:
         default:
           description: default response
@@ -323,34 +432,223 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DataPlaneInstance'
+                  $ref: '#/components/schemas/TransferProcessDto'
     post:
-      operationId: addEntry
+      operationId: initiateTransfer
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DataPlaneInstance'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /instances/select:
-    post:
-      operationId: find
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SelectionRequest'
+              $ref: '#/components/schemas/TransferRequestDto'
       responses:
         default:
           description: default response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DataPlaneInstance'
+                type: string
+  /transferprocess/{id}:
+    get:
+      operationId: getTransferProcess
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransferProcessDto'
+  /transferprocess/{id}/state:
+    get:
+      operationId: getTransferProcessState
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /contractdefinitions:
+    get:
+      operationId: getAllContractDefinitions
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractDefinitionDto'
+    post:
+      operationId: createContractDefinition
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ContractDefinitionDto'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /contractdefinitions/{id}:
+    get:
+      operationId: getContractDefinition
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractDefinitionDto'
+    delete:
+      operationId: deleteContractDefinition
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /identity-hub/query-commits:
+    post:
+      operationId: queryCommits
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/query-objects:
+    post:
+      operationId: queryObjects
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/collections:
+    post:
+      operationId: write
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/collections-commit:
+    post:
+      operationId: writeCommit
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
   /assets:
     get:
       operationId: getAllAssets
@@ -520,394 +818,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ContractAgreementDto'
-  /check/health:
-    get:
-      operationId: checkHealth
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /check/liveness:
-    get:
-      operationId: getLiveness
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /check/readiness:
-    get:
-      operationId: getReadiness
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /check/startup:
-    get:
-      operationId: getStartup
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /transferprocess/{id}/cancel:
-    post:
-      operationId: cancelTransferProcess
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /transferprocess/{id}/deprovision:
-    post:
-      operationId: deprovisionTransferProcess
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /transferprocess:
-    get:
-      operationId: getAllTransferProcesses
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/TransferProcessDto'
-    post:
-      operationId: initiateTransfer
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TransferRequestDto'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /transferprocess/{id}:
-    get:
-      operationId: getTransferProcess
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TransferProcessDto'
-  /transferprocess/{id}/state:
-    get:
-      operationId: getTransferProcessState
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /policies:
-    get:
-      operationId: getAllPolicies
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/PolicyDefinitionDto'
-    post:
-      operationId: createPolicy
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PolicyDefinitionDto'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /policies/{id}:
-    get:
-      operationId: getPolicy
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PolicyDefinitionDto'
-    delete:
-      operationId: deletePolicy
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /catalog:
-    post:
-      operationId: getCatalog
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FederatedCatalogCacheQuery'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractOffer'
-  /contractdefinitions:
-    get:
-      operationId: getAllContractDefinitions
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractDefinitionDto'
-    post:
-      operationId: createContractDefinition
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ContractDefinitionDto'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /contractdefinitions/{id}:
-    get:
-      operationId: getContractDefinition
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ContractDefinitionDto'
-    delete:
-      operationId: deleteContractDefinition
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
   /callback:
     post:
       operationId: callWebhook
@@ -916,6 +826,96 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ProvisionerWebhookRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /control/catalog:
+    get:
+      operationId: getDescription
+      parameters:
+      - name: provider
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /control/transfer:
+    post:
+      operationId: addTransfer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /control/agreement/{id}:
+    get:
+      operationId: getAgreementById
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /control/negotiation/{id}:
+    get:
+      operationId: getNegotiationById
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /control/negotiation/{id}/state:
+    get:
+      operationId: getNegotiationStateById
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /control/negotiation:
+    post:
+      operationId: initiateNegotiation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ContractOfferRequest'
       responses:
         default:
           description: default response

--- a/resources/openapi/yaml/selector-api.yaml
+++ b/resources/openapi/yaml/selector-api.yaml
@@ -44,21 +44,21 @@ components:
     DataPlaneInstance:
       type: object
       properties:
-        id:
-          type: string
-        url:
-          type: string
-          format: url
-        turnCount:
-          type: integer
-          format: int32
         lastActive:
           type: integer
           format: int64
+        turnCount:
+          type: integer
+          format: int32
+        url:
+          type: string
+          format: url
         properties:
           type: object
           additionalProperties:
             type: object
+        id:
+          type: string
     DataAddress:
       type: object
       properties:

--- a/resources/openapi/yaml/transferprocess.yaml
+++ b/resources/openapi/yaml/transferprocess.yaml
@@ -66,26 +66,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/TransferProcessDto'
-    post:
-      operationId: initiateTransfer
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TransferRequestDto'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
   /transferprocess/{id}:
     get:
       operationId: getTransferProcess
@@ -111,6 +91,21 @@ paths:
         required: true
         schema:
           type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /transferprocess/request:
+    post:
+      operationId: initiateTransfer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransferRequestDto'
       responses:
         default:
           description: default response
@@ -169,6 +164,8 @@ components:
         protocol:
           type: string
         connectorId:
+          type: string
+        assetId:
           type: string
     TransferType:
       type: object

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
@@ -104,7 +104,6 @@ public class DataRequest implements RemoteMessage, Polymorphic {
         return assetId;
     }
 
-
     /**
      * The id of the requested contract.
      */


### PR DESCRIPTION
## What this PR changes/adds

- Implementation of TransferProcessApiController 
- implementation of initiateTransfer method
- Unit tests
- Integration tests
- OpenAPI specs updated

## Why it does that

Implementation of stub methods.

## Further notes

After updating OpenApi specs using
```
./gradlew clean resolve
./gradlew mergeOpenApiFiles
```
some files unrelated to transferprocess was updated as well (selector-api.yaml).

## Linked Issue(s)

Linked to #210 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
