### PR TITLE
DataManagementApi: Implementation of initiateTransfer in TransferProcessApiController

### DIFF
--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApi.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApi.java
@@ -34,5 +34,5 @@ public interface TransferProcessApi {
 
     void deprovisionTransferProcess(String id);
 
-    String initiateTransfer(String assetId, TransferRequestDto transferRequest);
+    String initiateTransfer(TransferRequestDto transferRequest);
 }

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiController.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiController.java
@@ -117,8 +117,14 @@ public class TransferProcessApiController implements TransferProcessApi {
         if (!isValid(transferRequest)) {
             throw new IllegalArgumentException("Transfer request body not valid");
         }
+
         monitor.debug("Starting transfer for asset " + assetId);
-        return service.initiateTransfer(dataRequest(assetId, transferRequest));
+        try {
+            return service.initiateTransfer(dataRequest(assetId, transferRequest));
+        } catch (Exception e) {
+            monitor.severe("Error during initiating the transfer with assetId:" + assetId);
+            throw new EdcException("Error during initiating the transfer with assetId:" + assetId, e);
+        }
     }
 
     @POST

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiController.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiController.java
@@ -117,7 +117,7 @@ public class TransferProcessApiController implements TransferProcessApi {
         if (!isValid(transferRequest)) {
             throw new IllegalArgumentException("Transfer request body not valid");
         }
-        monitor.debug("Starting transfer for asset " + assetId + "to " + transferRequest.getDataDestination());
+        monitor.debug("Starting transfer for asset " + assetId);
         return service.initiateTransfer(dataRequest(assetId, transferRequest));
     }
 

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiController.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiController.java
@@ -36,6 +36,7 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 
 import java.util.List;
@@ -117,7 +118,7 @@ public class TransferProcessApiController implements TransferProcessApi {
             throw new IllegalArgumentException("Transfer request body not valid");
         }
         monitor.debug("Starting transfer for asset " + assetId + "to " + transferRequest.getDataDestination());
-        return "not-implemented"; //will be the transfer process id
+        return service.initiateTransfer(dataRequest(assetId, transferRequest));
     }
 
     @POST
@@ -144,6 +145,22 @@ public class TransferProcessApiController implements TransferProcessApi {
         } else {
             handleFailedResult(result, id);
         }
+    }
+
+    private DataRequest dataRequest(String assetId, TransferRequestDto object) {
+        return DataRequest.Builder.newInstance()
+                .assetId(assetId)
+                .connectorId(object.getConnectorId())
+                .dataDestination(object.getDataDestination())
+                .connectorAddress(object.getConnectorAddress())
+                .contractId(object.getContractId())
+                .transferType(object.getTransferType())
+                .destinationType(object.getDataDestination().getType())
+                .properties(object.getProperties())
+                .managedResources(object.isManagedResources())
+                .protocol(object.getProtocol())
+                .dataDestination(object.getDataDestination())
+                .build();
     }
 
     private boolean isValid(TransferRequestDto transferRequest) {

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferRequestDto.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferRequestDto.java
@@ -34,6 +34,7 @@ public class TransferRequestDto {
     private TransferType transferType;
     private String protocol = "ids-multipart";
     private String connectorId;
+    private String assetId;
 
     public String getConnectorAddress() {
         return connectorAddress;
@@ -65,6 +66,10 @@ public class TransferRequestDto {
 
     public String getConnectorId() {
         return connectorId;
+    }
+
+    public String getAssetId() {
+        return assetId;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -117,6 +122,11 @@ public class TransferRequestDto {
 
         public Builder connectorId(String connectorId) {
             request.connectorId = connectorId;
+            return this;
+        }
+
+        public Builder assetId(String assetId) {
+            request.assetId = assetId;
             return this;
         }
 

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessService.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessService.java
@@ -84,8 +84,8 @@ public interface TransferProcessService {
      * Initiate transfer request.
      *
      * @param request for the transfer.
-     * @return id of created transferProcess.
+     * @return a result that is successful if the transfer process was initiated with id of created transferProcess.
      */
     @NotNull
-    String initiateTransfer(DataRequest request);
+    ServiceResult<String> initiateTransfer(DataRequest request);
 }

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessService.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessService.java
@@ -14,9 +14,12 @@
 
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.service;
 
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
 import org.eclipse.dataspaceconnector.api.result.ServiceResult;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -76,4 +79,13 @@ public interface TransferProcessService {
      */
     @NotNull
     ServiceResult<TransferProcess> deprovision(String transferProcessId);
+
+    /**
+     * Initiate transfer request.
+     *
+     * @param request for the transfer.
+     * @return id of created transferProcess.
+     */
+    @NotNull
+    String initiateTransfer(DataRequest request);
 }

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImpl.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImpl.java
@@ -17,8 +17,10 @@ package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.servic
 import org.eclipse.dataspaceconnector.api.result.ServiceResult;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResult;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.CancelTransferCommand;
@@ -70,6 +72,12 @@ public class TransferProcessServiceImpl implements TransferProcessService {
     @Override
     public @NotNull ServiceResult<TransferProcess> deprovision(String transferProcessId) {
         return apply(transferProcessId, this::deprovisionImpl);
+    }
+
+    @Override
+    public @NotNull String initiateTransfer(DataRequest request) {
+        TransferInitiateResult transferInitiateResult = manager.initiateConsumerRequest(request);
+        return transferInitiateResult.getContent();
     }
 
     private ServiceResult<TransferProcess> apply(String transferProcessId, Function<TransferProcess, ServiceResult<TransferProcess>> function) {

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImpl.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImpl.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.servic
 
 import org.eclipse.dataspaceconnector.api.result.ServiceResult;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
+import org.eclipse.dataspaceconnector.spi.result.AbstractResult;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResult;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
@@ -75,10 +76,13 @@ public class TransferProcessServiceImpl implements TransferProcessService {
     }
 
     @Override
-    public @NotNull String initiateTransfer(DataRequest request) {
+    public @NotNull ServiceResult<String> initiateTransfer(DataRequest request) {
         return transactionContext.execute(() -> {
             TransferInitiateResult transferInitiateResult = manager.initiateConsumerRequest(request);
-            return transferInitiateResult.getContent();
+            return Optional.ofNullable(transferInitiateResult)
+                    .map(AbstractResult::getContent)
+                    .map(ServiceResult::success)
+                    .orElse(ServiceResult.conflict("Request couldn't be initialised."));
         });
     }
 

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImpl.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImpl.java
@@ -76,8 +76,10 @@ public class TransferProcessServiceImpl implements TransferProcessService {
 
     @Override
     public @NotNull String initiateTransfer(DataRequest request) {
-        TransferInitiateResult transferInitiateResult = manager.initiateConsumerRequest(request);
-        return transferInitiateResult.getContent();
+        return transactionContext.execute(() -> {
+            TransferInitiateResult transferInitiateResult = manager.initiateConsumerRequest(request);
+            return transferInitiateResult.getContent();
+        });
     }
 
     private ServiceResult<TransferProcess> apply(String transferProcessId, Function<TransferProcess, ServiceResult<TransferProcess>> function) {

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImpl.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImpl.java
@@ -80,6 +80,7 @@ public class TransferProcessServiceImpl implements TransferProcessService {
         return transactionContext.execute(() -> {
             TransferInitiateResult transferInitiateResult = manager.initiateConsumerRequest(request);
             return Optional.ofNullable(transferInitiateResult)
+                    .filter(AbstractResult::succeeded)
                     .map(AbstractResult::getContent)
                     .map(ServiceResult::success)
                     .orElse(ServiceResult.conflict("Request couldn't be initialised."));

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferRequestDtoToDataRequestTransformer.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferRequestDtoToDataRequestTransformer.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
+
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformer;
+import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+public class TransferRequestDtoToDataRequestTransformer implements DtoTransformer<TransferRequestDto, DataRequest> {
+
+    @Override
+    public Class<TransferRequestDto> getInputType() {
+        return TransferRequestDto.class;
+    }
+
+    @Override
+    public Class<DataRequest> getOutputType() {
+        return DataRequest.class;
+    }
+
+    @Override
+    public @Nullable DataRequest transform(@Nullable TransferRequestDto object, @NotNull TransformerContext context) {
+        Objects.requireNonNull(context);
+        if (object == null) {
+            return null;
+        }
+        return DataRequest.Builder.newInstance()
+                .assetId(object.getAssetId())
+                .connectorId(object.getConnectorId())
+                .dataDestination(object.getDataDestination())
+                .connectorAddress(object.getConnectorAddress())
+                .contractId(object.getContractId())
+                .transferType(object.getTransferType())
+                .destinationType(object.getDataDestination().getType())
+                .properties(object.getProperties())
+                .managedResources(object.isManagedResources())
+                .protocol(object.getProtocol())
+                .dataDestination(object.getDataDestination())
+                .build();
+    }
+}

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiApiControllerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiApiControllerTest.java
@@ -22,6 +22,7 @@ import org.eclipse.dataspaceconnector.api.exception.ObjectExistsException;
 import org.eclipse.dataspaceconnector.api.exception.ObjectNotFoundException;
 import org.eclipse.dataspaceconnector.api.result.ServiceResult;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
+import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.query.Criterion;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
@@ -207,6 +208,13 @@ class TransferProcessApiApiControllerTest {
         assertThat(dataRequest.isManagedResources()).isEqualTo(transferReq.isManagedResources());
 
         assertThat(result).isEqualTo(processId);
+    }
+
+    @Test
+    void initiateTransfer_failure() {
+        when(service.initiateTransfer(any())).thenThrow(new RuntimeException());
+
+        assertThatThrownBy(() -> controller.initiateTransfer("assetId", transferRequestDto())).isInstanceOf(EdcException.class);
     }
 
     @ParameterizedTest

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiApiControllerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiApiControllerTest.java
@@ -30,7 +30,6 @@ import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -38,6 +37,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -182,7 +182,27 @@ class TransferProcessApiApiControllerTest {
         assertThatThrownBy(() -> controller.cancelTransferProcess(transferProcess.getId())).isInstanceOf(ObjectNotFoundException.class);
     }
 
-    @Disabled
+    @Test
+    void initiateTransfer() {
+        var rq = transferRequestDto();
+        String processId = "processId";
+        when(service.initiateTransfer(any())).thenReturn(processId);
+
+        String result = controller.initiateTransfer("assetId", rq);
+        assertThat(result).isEqualTo(processId);
+    }
+
+    private TransferRequestDto transferRequestDto() {
+        return TransferRequestDto.Builder.newInstance()
+                .connectorAddress("http://some-contract")
+                .contractId("some-contract")
+                .protocol("test-asset")
+                .dataDestination(DataAddress.Builder.newInstance().type("test-type").build())
+                .connectorId("connectorId")
+                .properties(Map.of("prop", "value"))
+                .build();
+    }
+
     @ParameterizedTest
     @MethodSource("getInvalidRequestParams")
     void initiateTransfer_invalidRequest(String connectorAddress, String contractId, String assetId, String protocol, DataAddress destination) {

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiApiControllerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiApiControllerTest.java
@@ -284,6 +284,7 @@ class TransferProcessApiApiControllerTest {
                 Arguments.of("http://someurl", "some-contract", "  ", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build())
         );
     }
+
     private void assertQuerySpec(int limit, int offset, SortOrder sortOrder, String sortField, Criterion... criterions) {
         ArgumentCaptor<QuerySpec> captor = ArgumentCaptor.forClass(QuerySpec.class);
         verify(service).query(captor.capture());

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiApiControllerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiApiControllerTest.java
@@ -192,17 +192,6 @@ class TransferProcessApiApiControllerTest {
         assertThat(result).isEqualTo(processId);
     }
 
-    private TransferRequestDto transferRequestDto() {
-        return TransferRequestDto.Builder.newInstance()
-                .connectorAddress("http://some-contract")
-                .contractId("some-contract")
-                .protocol("test-asset")
-                .dataDestination(DataAddress.Builder.newInstance().type("test-type").build())
-                .connectorId("connectorId")
-                .properties(Map.of("prop", "value"))
-                .build();
-    }
-
     @ParameterizedTest
     @MethodSource("getInvalidRequestParams")
     void initiateTransfer_invalidRequest(String connectorAddress, String contractId, String assetId, String protocol, DataAddress destination) {
@@ -215,6 +204,17 @@ class TransferProcessApiApiControllerTest {
         assertThatThrownBy(() -> controller.initiateTransfer(assetId, rq)).isInstanceOfAny(IllegalArgumentException.class);
     }
 
+
+    private TransferRequestDto transferRequestDto() {
+        return TransferRequestDto.Builder.newInstance()
+                .connectorAddress("http://some-contract")
+                .contractId("some-contract")
+                .protocol("test-asset")
+                .dataDestination(DataAddress.Builder.newInstance().type("test-type").build())
+                .connectorId("connectorId")
+                .properties(Map.of("prop", "value"))
+                .build();
+    }
 
     // provides invalid values for a TransferRequestDto
     public static Stream<Arguments> getInvalidRequestParams() {

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiApiControllerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiApiControllerTest.java
@@ -227,15 +227,6 @@ class TransferProcessApiApiControllerTest {
         assertThatThrownBy(() -> controller.initiateTransfer(transferRequestDto())).isInstanceOf(EdcException.class);
     }
 
-    @Test
-    void initiateTransfer_exceptionThrown() {
-        var dataRequest = dataRequest();
-        when(transformerRegistry.transform(isA(TransferRequestDto.class), eq(DataRequest.class))).thenReturn(Result.success(dataRequest));
-        when(service.initiateTransfer(any())).thenThrow(new RuntimeException());
-
-        assertThatThrownBy(() -> controller.initiateTransfer(transferRequestDto())).isInstanceOf(EdcException.class);
-    }
-
     @ParameterizedTest
     @MethodSource("getInvalidRequestParams")
     void initiateTransfer_invalidRequest(String connectorAddress, String contractId, String assetId, String protocol, DataAddress destination) {
@@ -262,11 +253,12 @@ class TransferProcessApiApiControllerTest {
     }
 
     private DataRequest dataRequest() {
-        return DataRequest.Builder.newInstance().build();
+        return DataRequest.Builder.newInstance()
+                .dataDestination(DataAddress.Builder.newInstance().type("dataaddress-type").build())
+                .build();
     }
 
     // provides invalid values for a TransferRequestDto
-
     public static Stream<Arguments> getInvalidRequestParams() {
         return Stream.of(
                 Arguments.of(null, "some-contract", "test-asset", "ids-multipart", DataAddress.Builder.newInstance().type("test-type").build()),

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiApiControllerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiApiControllerTest.java
@@ -28,6 +28,7 @@ import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.query.SortOrder;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -184,11 +185,27 @@ class TransferProcessApiApiControllerTest {
 
     @Test
     void initiateTransfer() {
-        var rq = transferRequestDto();
+        var transferReq = transferRequestDto();
         String processId = "processId";
+        String assetId = "assetId";
         when(service.initiateTransfer(any())).thenReturn(processId);
 
-        String result = controller.initiateTransfer("assetId", rq);
+        String result = controller.initiateTransfer(assetId, transferReq);
+
+        var dataRequestCaptor = ArgumentCaptor.forClass(DataRequest.class);
+        verify(service).initiateTransfer(dataRequestCaptor.capture());
+        DataRequest dataRequest = dataRequestCaptor.getValue();
+        assertThat(dataRequest.getAssetId()).isEqualTo(assetId);
+        assertThat(dataRequest.getConnectorAddress()).isEqualTo(transferReq.getConnectorAddress());
+        assertThat(dataRequest.getConnectorId()).isEqualTo(transferReq.getConnectorId());
+        assertThat(dataRequest.getDataDestination()).isEqualTo(transferReq.getDataDestination());
+        assertThat(dataRequest.getDestinationType()).isEqualTo(transferReq.getDataDestination().getType());
+        assertThat(dataRequest.getContractId()).isEqualTo(transferReq.getContractId());
+        assertThat(dataRequest.getProtocol()).isEqualTo(transferReq.getProtocol());
+        assertThat(dataRequest.getProperties()).isEqualTo(transferReq.getProperties());
+        assertThat(dataRequest.getTransferType()).isEqualTo(transferReq.getTransferType());
+        assertThat(dataRequest.isManagedResources()).isEqualTo(transferReq.isManagedResources());
+
         assertThat(result).isEqualTo(processId);
     }
 

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
@@ -15,8 +15,10 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 
 import io.restassured.specification.RequestSpecification;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.junit.jupiter.api.BeforeEach;
@@ -197,6 +199,42 @@ class TransferProcessApiControllerIntegrationTest {
                 .post("/transferprocess/" + PROCESS_ID + "/deprovision")
                 .then()
                 .statusCode(409);
+    }
+
+    @Test
+    void initiateRequest(TransferProcessStore store) {
+        var assetId = "assetId";
+        var request = TransferRequestDto.Builder.newInstance()
+                .connectorAddress("http://some-contract")
+                .contractId("some-contract")
+                .protocol("test-asset")
+                .dataDestination(DataAddress.Builder.newInstance().type("test-type").build())
+                .connectorId("connectorId")
+                .properties(Map.of("prop", "value"))
+                .build();
+
+        var result = baseRequest()
+                .contentType(JSON)
+                .body(request)
+                .post("/transferprocess/" + assetId + "/request")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        assertThat(result).isNotBlank();
+    }
+
+    @Test
+    void initiateRequest_badRequest() {
+
+        baseRequest()
+                .contentType(JSON)
+                .body("bad-request")
+                .post("/transferprocess/assetId/request")
+                .then()
+                .statusCode(400)
+                .extract().body().asString();
+
     }
 
     private TransferProcess createTransferProcess(String processId) {

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
@@ -203,11 +203,11 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void initiateRequest(TransferProcessStore store) {
-        var assetId = "assetId";
         var request = TransferRequestDto.Builder.newInstance()
                 .connectorAddress("http://some-contract")
                 .contractId("some-contract")
                 .protocol("test-asset")
+                .assetId("assetId")
                 .dataDestination(DataAddress.Builder.newInstance().type("test-type").build())
                 .connectorId("connectorId")
                 .properties(Map.of("prop", "value"))
@@ -216,7 +216,7 @@ class TransferProcessApiControllerIntegrationTest {
         var result = baseRequest()
                 .contentType(JSON)
                 .body(request)
-                .post("/transferprocess/" + assetId + "/request")
+                .post("/transferprocess/request")
                 .then()
                 .statusCode(200)
                 .extract().body().asString();
@@ -230,7 +230,7 @@ class TransferProcessApiControllerIntegrationTest {
         baseRequest()
                 .contentType(JSON)
                 .body("bad-request")
-                .post("/transferprocess/assetId/request")
+                .post("/transferprocess/request")
                 .then()
                 .statusCode(400)
                 .extract().body().asString();

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImplTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImplTest.java
@@ -18,8 +18,10 @@ import com.github.javafaker.Faker;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResult;
 import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.CancelTransferCommand;
@@ -134,6 +136,15 @@ class TransferProcessServiceImplTest {
 
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureMessages()).containsExactly("TransferProcess " + id + " does not exist");
+    }
+
+    @Test
+    void initiateTransfer() {
+        var dataRequest = DataRequest.Builder.newInstance().destinationType("type").build();
+        String processId = "processId";
+
+        when(manager.initiateConsumerRequest(dataRequest)).thenReturn(TransferInitiateResult.success(processId));
+        assertThat(service.initiateTransfer(dataRequest)).isEqualTo(processId);
     }
 
     public static List<TransferProcessStates> cancellableStates() {

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImplTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImplTest.java
@@ -145,7 +145,9 @@ class TransferProcessServiceImplTest {
         String processId = "processId";
 
         when(manager.initiateConsumerRequest(dataRequest)).thenReturn(TransferInitiateResult.success(processId));
-        assertThat(service.initiateTransfer(dataRequest)).isEqualTo(ServiceResult.success(processId));
+        ServiceResult<String> result = service.initiateTransfer(dataRequest);
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).isEqualTo(processId);
     }
 
     public static List<TransferProcessStates> cancellableStates() {

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImplTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/service/TransferProcessServiceImplTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.service;
 
 import com.github.javafaker.Faker;
+import org.eclipse.dataspaceconnector.api.result.ServiceResult;
 import org.eclipse.dataspaceconnector.spi.query.QuerySpec;
 import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
@@ -144,7 +145,7 @@ class TransferProcessServiceImplTest {
         String processId = "processId";
 
         when(manager.initiateConsumerRequest(dataRequest)).thenReturn(TransferInitiateResult.success(processId));
-        assertThat(service.initiateTransfer(dataRequest)).isEqualTo(processId);
+        assertThat(service.initiateTransfer(dataRequest)).isEqualTo(ServiceResult.success(processId));
     }
 
     public static List<TransferProcessStates> cancellableStates() {

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferRequestDtoToDataRequestTransformerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferRequestDtoToDataRequestTransformerTest.java
@@ -1,0 +1,60 @@
+package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform;
+
+import com.github.javafaker.Faker;
+import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
+import org.eclipse.dataspaceconnector.api.transformer.DtoTransformer;
+import org.eclipse.dataspaceconnector.spi.transformer.TransformerContext;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class TransferRequestDtoToDataRequestTransformerTest {
+
+    private static Faker faker = new Faker();
+    private DtoTransformer<TransferRequestDto, DataRequest> transformer = new TransferRequestDtoToDataRequestTransformer();
+
+    @Test
+    void getInputType() {
+        assertThat(transformer.getInputType()).isEqualTo(TransferRequestDto.class);
+    }
+
+    @Test
+    void getOutputType() {
+        assertThat(transformer.getOutputType()).isEqualTo(DataRequest.class);
+    }
+
+    @Test
+    void transform() {
+        var context = mock(TransformerContext.class);
+        var transferReq = transferRequestDto();
+        var dataRequest = transformer.transform(transferReq, context);
+        assertThat(dataRequest.getAssetId()).isEqualTo(transferReq.getAssetId());
+        assertThat(dataRequest.getConnectorAddress()).isEqualTo(transferReq.getConnectorAddress());
+        assertThat(dataRequest.getConnectorId()).isEqualTo(transferReq.getConnectorId());
+        assertThat(dataRequest.getDataDestination()).isEqualTo(transferReq.getDataDestination());
+        assertThat(dataRequest.getDestinationType()).isEqualTo(transferReq.getDataDestination().getType());
+        assertThat(dataRequest.getContractId()).isEqualTo(transferReq.getContractId());
+        assertThat(dataRequest.getProtocol()).isEqualTo(transferReq.getProtocol());
+        assertThat(dataRequest.getProperties()).isEqualTo(transferReq.getProperties());
+        assertThat(dataRequest.getTransferType()).isEqualTo(transferReq.getTransferType());
+        assertThat(dataRequest.isManagedResources()).isEqualTo(transferReq.isManagedResources());
+    }
+
+    private TransferRequestDto transferRequestDto() {
+        return TransferRequestDto.Builder.newInstance()
+                .connectorAddress(faker.internet().url())
+                .assetId(faker.lorem().word())
+                .contractId(faker.lorem().word())
+                .protocol(faker.lorem().word())
+                .dataDestination(DataAddress.Builder.newInstance().type(faker.lorem().word()).build())
+                .connectorId(faker.lorem().word())
+                .properties(Map.of(faker.lorem().word(), faker.lorem().word()))
+                .build();
+    }
+
+}

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
@@ -104,7 +104,6 @@ public class DataRequest implements RemoteMessage, Polymorphic {
         return assetId;
     }
 
-
     /**
      * The id of the requested contract.
      */


### PR DESCRIPTION
## What this PR changes/adds

Implementation of initiateTransfer method in TransferProcessApiController.

## Why it does that

Implementation of stubbed method.

## Further notes

⚠️ ~This is a proposal of the _initiateTransfer_ method behavior, but it's not yet confirmed.~ - this PR was pre-reviewed by Andrea and updated according to the suggestions. After the feedback  the signature of the Controller _initiateTransfer_ method was changed to `String initiateTransfer(TransferRequestDto transferRequest)`.

## Linked Issue(s)

With PR #214 Closes issue #210 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
