### PR TITLE
Observability: trace context propagation in DPF

### DIFF
--- a/extensions/data-plane-transfer/data-plane-transfer-client/build.gradle.kts
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 val httpMockServer: String by project
 val jodahFailsafeVersion: String by project
 val okHttpVersion: String by project
+val openTelemetryVersion: String by project
 val faker: String by project
 
 dependencies {
@@ -30,6 +31,7 @@ dependencies {
 
     implementation("net.jodah:failsafe:${jodahFailsafeVersion}")
     implementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
+    implementation("io.opentelemetry:opentelemetry-extension-annotations:${openTelemetryVersion}")
 
     testImplementation("org.mock-server:mockserver-netty:${httpMockServer}:shaded")
     testImplementation("org.mock-server:mockserver-client-java:${httpMockServer}:shaded")

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/EmbeddedDataPlaneTransferClient.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/EmbeddedDataPlaneTransferClient.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.transfer.dataplane.client;
 
+import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.dataspaceconnector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.dataspaceconnector.dataplane.spi.result.TransferResult;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
@@ -31,6 +32,7 @@ public class EmbeddedDataPlaneTransferClient implements DataPlaneTransferClient 
         this.dataPlaneManager = dataPlaneManager;
     }
 
+    @WithSpan
     @Override
     public TransferResult transfer(DataFlowRequest request) {
         var result = dataPlaneManager.validate(request);

--- a/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/RemoteDataPlaneTransferClient.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-client/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/client/RemoteDataPlaneTransferClient.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.transfer.dataplane.client;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.extension.annotations.WithSpan;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 import okhttp3.MediaType;
@@ -57,6 +58,7 @@ public class RemoteDataPlaneTransferClient implements DataPlaneTransferClient {
         this.mapper = mapper;
     }
 
+    @WithSpan
     @Override
     public TransferResult transfer(DataFlowRequest request) {
         var instance = selectorClient.find(request.getSourceDataAddress(), request.getDestinationDataAddress(), selectorStrategy);

--- a/extensions/data-plane/data-plane-framework/build.gradle.kts
+++ b/extensions/data-plane/data-plane-framework/build.gradle.kts
@@ -12,6 +12,8 @@
  *
  */
 
+val openTelemetryVersion: String by project
+
 plugins {
     `java-library`
 }
@@ -20,6 +22,7 @@ dependencies {
     api(project(":spi:core-spi"))
     api(project(":extensions:data-plane:data-plane-spi"))
     implementation(project(":common:util"))
+    implementation("io.opentelemetry:opentelemetry-extension-annotations:${openTelemetryVersion}")
     testImplementation(testFixtures(project(":launchers:junit")))
 }
 

--- a/extensions/data-plane/data-plane-framework/build.gradle.kts
+++ b/extensions/data-plane/data-plane-framework/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
 }
 
 dependencies {
+    api(project(":spi:core-spi"))
     api(project(":extensions:data-plane:data-plane-spi"))
     implementation(project(":common:util"))
     testImplementation(testFixtures(project(":launchers:junit")))

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtension.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtension.java
@@ -96,6 +96,8 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
         context.registerService(DataTransferExecutorServiceContainer.class, executorContainer);
 
         monitor = context.getMonitor();
+        var telemetry = context.getTelemetry();
+
         var queueCapacity = context.getSetting(QUEUE_CAPACITY, DEFAULT_QUEUE_CAPACITY);
         var workers = context.getSetting(WORKERS, DEFAULT_WORKERS);
         var waitTimeout = context.getSetting(WAIT_TIMEOUT, DEFAULT_WAIT_TIMEOUT);
@@ -108,7 +110,9 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
                 .pipelineService(pipelineService)
                 .transferServiceRegistry(transferServiceRegistry)
                 .store(new InMemoryDataPlaneStore(IN_MEMORY_STORE_CAPACITY))
-                .monitor(monitor).build();
+                .monitor(monitor)
+                .telemetry(telemetry)
+                .build();
 
         context.registerService(DataPlaneManager.class, dataPlaneManager);
     }

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/manager/DataPlaneManagerImpl.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/manager/DataPlaneManagerImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.dataspaceconnector.dataplane.spi.store.DataPlaneStore.State;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
+import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
 
 import java.util.concurrent.ArrayBlockingQueue;
@@ -49,6 +50,7 @@ public class DataPlaneManagerImpl implements DataPlaneManager {
     private PipelineService pipelineService;
     private ExecutorInstrumentation executorInstrumentation;
     private Monitor monitor;
+    private Telemetry telemetry;
 
     private BlockingQueue<DataFlowRequest> queue;
     private ExecutorService executorService;
@@ -89,8 +91,12 @@ public class DataPlaneManagerImpl implements DataPlaneManager {
     }
 
     public void initiateTransfer(DataFlowRequest dataRequest) {
-        queue.add(dataRequest);
-        store.received(dataRequest.getProcessId());
+        // store current trace context in entity for request traceability
+        DataFlowRequest dataRequestWithTraceContext = dataRequest.toBuilder()
+                .traceContext(telemetry.getCurrentTraceContext())
+                .build();
+        queue.add(dataRequestWithTraceContext);
+        store.received(dataRequestWithTraceContext.getProcessId());
     }
 
     @Override
@@ -116,21 +122,9 @@ public class DataPlaneManagerImpl implements DataPlaneManager {
                 if (request == null) {
                     continue;
                 }
-                final var polledRequest = request;
+                // propagate trace context for request into the current thread
+                telemetry.contextPropagationMiddleware(this::processDataFlowRequest).accept(request);
 
-                var transferService = transferServiceRegistry.resolveTransferService(polledRequest);
-                if (transferService == null) {
-                    // Should not happen since resolving a transferService is part of payload validation
-                    // TODO persist error details
-                    store.completed(polledRequest.getProcessId());
-                } else {
-                    transferService.transfer(request).whenComplete((result, exception) -> {
-                        if (polledRequest.isTrackable()) {
-                            // TODO persist TransferResult or error details
-                            store.completed(polledRequest.getProcessId());
-                        }
-                    });
-                }
             } catch (InterruptedException e) {
                 Thread.interrupted();
                 active.set(false);
@@ -144,6 +138,22 @@ public class DataPlaneManagerImpl implements DataPlaneManager {
                     store.completed(request.getProcessId());
                 }
             }
+        }
+    }
+
+    private void processDataFlowRequest(DataFlowRequest request) {
+        var transferService = transferServiceRegistry.resolveTransferService(request);
+        if (transferService == null) {
+            // Should not happen since resolving a transferService is part of payload validation
+            // TODO persist error details
+            store.completed(request.getProcessId());
+        } else {
+            transferService.transfer(request).whenComplete((result, exception) -> {
+                if (request.isTrackable()) {
+                    // TODO persist TransferResult or error details
+                    store.completed(request.getProcessId());
+                }
+            });
         }
     }
 
@@ -174,6 +184,11 @@ public class DataPlaneManagerImpl implements DataPlaneManager {
             return this;
         }
 
+        public Builder telemetry(Telemetry telemetry) {
+            manager.telemetry = telemetry;
+            return this;
+        }
+
         public Builder queueCapacity(int capacity) {
             manager.queueCapacity = capacity;
             return this;
@@ -200,6 +215,7 @@ public class DataPlaneManagerImpl implements DataPlaneManager {
 
         private Builder() {
             manager = new DataPlaneManagerImpl();
+            this.manager.telemetry = new Telemetry(); // default noop implementation
         }
     }
 

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/pipeline/PipelineServiceImpl.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/pipeline/PipelineServiceImpl.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.dataplane.framework.pipeline;
 
+import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSink;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSinkFactory;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSource;
@@ -73,6 +74,7 @@ public class PipelineServiceImpl implements PipelineService {
         return Result.success(true);
     }
 
+    @WithSpan
     @Override
     public CompletableFuture<TransferResult> transfer(DataFlowRequest request) {
         var sourceFactory = getSourceFactory(request);

--- a/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/pipeline/PipelineServiceTransferServiceImpl.java
+++ b/extensions/data-plane/data-plane-framework/src/main/java/org/eclipse/dataspaceconnector/dataplane/framework/pipeline/PipelineServiceTransferServiceImpl.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.dataplane.framework.pipeline;
 
+import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.TransferService;
 import org.eclipse.dataspaceconnector.dataplane.spi.result.TransferResult;
@@ -43,6 +44,7 @@ public class PipelineServiceTransferServiceImpl implements TransferService {
         return pipelineService.validate(request);
     }
 
+    @WithSpan
     @Override
     public CompletableFuture<TransferResult> transfer(DataFlowRequest request) {
         return pipelineService.transfer(request);

--- a/extensions/data-plane/data-plane-spi/build.gradle.kts
+++ b/extensions/data-plane/data-plane-spi/build.gradle.kts
@@ -13,6 +13,7 @@
  */
 
 val mockitoVersion: String by project
+val openTelemetryVersion: String by project
 
 plugins {
     `java-library`
@@ -21,6 +22,7 @@ plugins {
 dependencies {
     api(project(":spi:core-spi"))
     implementation(project(":common:util"))
+    implementation("io.opentelemetry:opentelemetry-extension-annotations:${openTelemetryVersion}")
 }
 
 

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSink.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSink.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.dataplane.spi.pipeline;
 
+import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.dataspaceconnector.common.stream.PartitionIterator;
 import org.eclipse.dataspaceconnector.dataplane.spi.result.TransferResult;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
@@ -43,6 +44,7 @@ public abstract class ParallelSink implements DataSink {
     protected Monitor monitor;
     protected Telemetry telemetry;
 
+    @WithSpan
     @Override
     public CompletableFuture<TransferResult> transfer(DataSource source) {
         try (var partStream = source.openPartStream()) {

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSink.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSink.java
@@ -18,11 +18,15 @@ import org.eclipse.dataspaceconnector.common.stream.PartitionIterator;
 import org.eclipse.dataspaceconnector.dataplane.spi.result.TransferResult;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.AbstractResult;
+import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
+import org.eclipse.dataspaceconnector.spi.telemetry.TraceCarrier;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static java.util.stream.Collectors.toList;
@@ -37,12 +41,15 @@ public abstract class ParallelSink implements DataSink {
     protected int partitionSize = 5;
     protected ExecutorService executorService;
     protected Monitor monitor;
+    protected Telemetry telemetry;
 
     @Override
     public CompletableFuture<TransferResult> transfer(DataSource source) {
         try (var partStream = source.openPartStream()) {
             var partitioned = PartitionIterator.streamOf(partStream, partitionSize);
-            var futures = partitioned.map(parts -> supplyAsync(() -> transferParts(parts), executorService)).collect(toList());
+            var traceCarrier = telemetry.getTraceCarrierWithCurrentContext();
+
+            var futures = partitioned.map(parts -> processPartsAsync(parts, traceCarrier)).collect(toList());
             return futures.stream()
                     .collect(asyncAllOf())
                     .thenApply(results -> results.stream()
@@ -57,6 +64,12 @@ public abstract class ParallelSink implements DataSink {
         }
     }
 
+    @NotNull
+    private CompletableFuture<TransferResult> processPartsAsync(List<DataSource.Part> parts, TraceCarrier traceCarrier) {
+        Supplier<TransferResult> supplier = () -> transferParts(parts);
+        return supplyAsync(telemetry.contextPropagationMiddleware(supplier, traceCarrier), executorService);
+    }
+
     protected abstract TransferResult transferParts(List<DataSource.Part> parts);
 
     protected abstract static class Builder<B extends Builder<B, T>, T extends ParallelSink> {
@@ -64,6 +77,7 @@ public abstract class ParallelSink implements DataSink {
 
         protected Builder(T sink) {
             this.sink = sink;
+            this.sink.telemetry = new Telemetry(); // default noop implementation
         }
 
         public B requestId(String requestId) {
@@ -83,6 +97,11 @@ public abstract class ParallelSink implements DataSink {
 
         public B monitor(Monitor monitor) {
             sink.monitor = monitor;
+            return self();
+        }
+
+        public B telemetry(Telemetry telemetry) {
+            sink.telemetry = telemetry;
             return self();
         }
 

--- a/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSinkTest.java
+++ b/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSinkTest.java
@@ -18,6 +18,7 @@ import com.github.javafaker.Faker;
 import org.eclipse.dataspaceconnector.dataplane.spi.result.TransferResult;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
+import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +38,7 @@ class ParallelSinkTest {
 
     Faker faker = new Faker();
     Monitor monitor = mock(Monitor.class);
+    Telemetry telemetry = new Telemetry(); // default noop impl
     ExecutorService executor = Executors.newFixedThreadPool(2);
     String dataSourceName = faker.lorem().word();
     String dataSourceContent = faker.lorem().characters();
@@ -48,6 +50,7 @@ class ParallelSinkTest {
     void setup() {
         fakeSink = new FakeParallelSink();
         fakeSink.monitor = monitor;
+        fakeSink.telemetry = telemetry;
         fakeSink.executorService = executor;
         fakeSink.requestId = UUID.randomUUID().toString();
     }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/telemetry/InMemoryTraceCarrier.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/telemetry/InMemoryTraceCarrier.java
@@ -11,18 +11,23 @@
  *       Microsoft Corporation - Initial implementation
  *
  */
-
 package org.eclipse.dataspaceconnector.spi.telemetry;
 
 import java.util.Map;
 
 /**
- * Interface for trace context carrier entities.
- *
- * Use in combination with {@link Telemetry#contextPropagationMiddleware} to propagate the tracing context stored in the entity to the current thread.
+ * Simple TraceCarrier to use in situations where no entity is persisted for asynchronous processing
  */
-public interface TraceCarrier {
+class InMemoryTraceCarrier implements TraceCarrier {
 
-    Map<String, String> getTraceContext();
+    private final Map<String, String> traceContext;
 
+    public InMemoryTraceCarrier(Map<String, String> traceContext) {
+        this.traceContext = traceContext;
+    }
+
+    @Override
+    public Map<String, String> getTraceContext() {
+        return traceContext;
+    }
 }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/telemetry/Telemetry.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/telemetry/Telemetry.java
@@ -54,6 +54,7 @@ public class Telemetry {
 
     /**
      * Returns a trace carrier object containing the trace context from the current thread
+     *
      * @return The trace carrier
      */
     public TraceCarrier getTraceCarrierWithCurrentContext() {

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/telemetry/Telemetry.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/telemetry/Telemetry.java
@@ -21,6 +21,7 @@ import io.opentelemetry.context.propagation.TextMapGetter;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -60,6 +61,20 @@ public class Telemetry {
         return (t) -> {
             try (Scope scope = propagateTraceContext(t)) {
                 return delegate.apply(t);
+            }
+        };
+    }
+
+    /**
+     * Wraps a consumer with a middleware to propagate the trace context present in the carrier to the executing thread
+     *
+     * @param delegate The wrapped consumer
+     * @return The resulting function with the context propagation middleware
+     */
+    public <T extends TraceCarrier> Consumer<T> contextPropagationMiddleware(Consumer<T> delegate) {
+        return (t) -> {
+            try (Scope scope = propagateTraceContext(t)) {
+                delegate.accept(t);
             }
         };
     }

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataFlowRequest.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataFlowRequest.java
@@ -18,9 +18,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.dataspaceconnector.spi.telemetry.TraceCarrier;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.Polymorphic;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -29,7 +32,7 @@ import java.util.Objects;
  */
 @JsonTypeName("dataspaceconnector:dataflowrequest")
 @JsonDeserialize(builder = DataFlowRequest.Builder.class)
-public class DataFlowRequest implements Polymorphic {
+public class DataFlowRequest implements Polymorphic, TraceCarrier {
     private String id;
     private String processId;
 
@@ -39,6 +42,7 @@ public class DataFlowRequest implements Polymorphic {
     private boolean trackable;
 
     private Map<String, String> properties = Map.of();
+    private Map<String, String> traceContext = Map.of();
 
     private DataFlowRequest() {
     }
@@ -85,12 +89,30 @@ public class DataFlowRequest implements Polymorphic {
         return properties;
     }
 
+    /**
+     * @return Trace context for this carrier
+     */
+    public Map<String, String> getTraceContext() {
+        return Collections.unmodifiableMap(traceContext);
+    }
+
+    /**
+     * @return A builder initialized with the current DataFlowRequest
+     */
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
         private final DataFlowRequest request;
 
         private Builder() {
-            request = new DataFlowRequest();
+            this(new DataFlowRequest());
+        }
+
+        private Builder(DataFlowRequest request) {
+            this.request = request;
         }
 
         @JsonCreator
@@ -137,10 +159,16 @@ public class DataFlowRequest implements Polymorphic {
             return this;
         }
 
+        public Builder traceContext(Map<String, String> value) {
+            request.traceContext = value == null ? null : Map.copyOf(value);
+            return this;
+        }
+
         public DataFlowRequest build() {
             Objects.requireNonNull(request.processId, "processId");
             Objects.requireNonNull(request.sourceDataAddress, "sourceDataAddress");
             Objects.requireNonNull(request.destinationDataAddress, "destinationDataAddress");
+            Objects.requireNonNull(request.traceContext, "traceContext");
             return request;
         }
 

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataFlowRequest.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataFlowRequest.java
@@ -90,14 +90,14 @@ public class DataFlowRequest implements Polymorphic, TraceCarrier {
     }
 
     /**
-     * @return Trace context for this carrier
+     * Trace context for this carrier
      */
     public Map<String, String> getTraceContext() {
         return Collections.unmodifiableMap(traceContext);
     }
 
     /**
-     * @return A builder initialized with the current DataFlowRequest
+     * A builder initialized with the current DataFlowRequest
      */
     public Builder toBuilder() {
         return new Builder(this);

--- a/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataFlowRequestTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataFlowRequestTest.java
@@ -36,11 +36,13 @@ class DataFlowRequestTest {
                 .processId(UUID.randomUUID().toString())
                 .destinationType("test")
                 .properties(Map.of("key", "value"))
+                .traceContext(Map.of("key2", "value2"))
                 .build();
         var serialized = mapper.writeValueAsString(request);
         var deserialized = mapper.readValue(serialized, DataFlowRequest.class);
 
         assertThat(deserialized).isNotNull();
         assertThat(deserialized.getProperties().get("key")).isEqualTo("value");
+        assertThat(deserialized.getTraceContext().get("key2")).isEqualTo("value2");
     }
 }

--- a/system-tests/runtimes/file-transfer-provider/build.gradle.kts
+++ b/system-tests/runtimes/file-transfer-provider/build.gradle.kts
@@ -13,6 +13,8 @@
  *
  */
 
+val openTelemetryVersion: String by project
+
 plugins {
     `java-library`
     id("application")
@@ -38,6 +40,7 @@ dependencies {
     api(project(":extensions:dataloading"))
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
+    implementation("io.opentelemetry:opentelemetry-extension-annotations:${openTelemetryVersion}")
 
     implementation(project(":core"))
 

--- a/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSink.java
+++ b/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSink.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.extensions.api;
 
+import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.ParallelSink;
 import org.eclipse.dataspaceconnector.dataplane.spi.result.TransferResult;
@@ -29,6 +30,7 @@ import static org.eclipse.dataspaceconnector.spi.response.ResponseStatus.ERROR_R
 class FileTransferDataSink extends ParallelSink {
     private File file;
 
+    @WithSpan
     @Override
     protected TransferResult transferParts(List<DataSource.Part> parts) {
         for (DataSource.Part part : parts) {

--- a/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSinkFactory.java
+++ b/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferDataSinkFactory.java
@@ -18,6 +18,7 @@ import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSink;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSinkFactory;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,11 +27,13 @@ import java.util.concurrent.ExecutorService;
 
 class FileTransferDataSinkFactory implements DataSinkFactory {
     private final Monitor monitor;
+    private final Telemetry telemetry;
     private final ExecutorService executorService;
     private final int partitionSize;
 
-    public FileTransferDataSinkFactory(Monitor monitor, ExecutorService executorService, int partitionSize) {
+    public FileTransferDataSinkFactory(Monitor monitor, Telemetry telemetry, ExecutorService executorService, int partitionSize) {
         this.monitor = monitor;
+        this.telemetry = telemetry;
         this.executorService = executorService;
         this.partitionSize = partitionSize;
     }
@@ -60,6 +63,7 @@ class FileTransferDataSinkFactory implements DataSinkFactory {
                 .partitionSize(partitionSize)
                 .executorService(executorService)
                 .monitor(monitor)
+                .telemetry(telemetry)
                 .build();
     }
 }

--- a/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
+++ b/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/dataspaceconnector/extensions/api/FileTransferExtension.java
@@ -47,11 +47,12 @@ public class FileTransferExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var monitor = context.getMonitor();
+        var telemetry = context.getTelemetry();
 
         var sourceFactory = new FileTransferDataSourceFactory();
         pipelineService.registerFactory(sourceFactory);
 
-        var sinkFactory = new FileTransferDataSinkFactory(monitor, executorContainer.getExecutorService(), 5);
+        var sinkFactory = new FileTransferDataSinkFactory(monitor, telemetry, executorContainer.getExecutorService(), 5);
         pipelineService.registerFactory(sinkFactory);
 
         var policy = createPolicy();


### PR DESCRIPTION
## What this PR changes/adds

Add trace context propagation at different points within DPF:
- `DataPlaneManagerImpl`: trace context is propagated to the corresponding async worker threads through the "DataFlowRequest" entities stored in the processing queue.
- `ParallelSink`: trace context is propagated to the async workers that process parts. No entity is persisted in this case, the trace context is propagated in memory.

## Why it does that

In order to have traces spanning across asynchronous calls it is required to propagate the tracing context to worker threads. See resulting trace visualitzation in Jaeger (both consumer and provider are labelled as "integrationtest"):

<img width="1292" alt="Screenshot 2022-04-03 at 12 43 11" src="https://user-images.githubusercontent.com/5342234/162393633-eaf61cb0-7c70-4e96-bb55-c00ba48a7f5b.png">

## Notes

This PR does not include integration tests yet. This will be done in a follow-up PR after https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/pull/1035 is merged

## Linked Issue(s)

Closes #173 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
