### PR TITLE
Feature/819/223 fix test categories

### DIFF
--- a/core/base/build.gradle.kts
+++ b/core/base/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(project(":core:policy:policy-engine"))
 
     testImplementation(testFixtures(project(":launchers:junit")))
+    testImplementation(testFixtures(project(":common:util")))
     testImplementation("org.awaitility:awaitility:${awaitility}")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
 }

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/CoreServicesExtensionIntegrationTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/CoreServicesExtensionIntegrationTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.core;
 
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.system.Hostname;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.core.CoreServicesExtension.HOSTNAME_SETTING;
 
 @ExtendWith(EdcExtension.class)
+@ComponentTest
 class CoreServicesExtensionIntegrationTest {
 
     @BeforeEach

--- a/core/base/src/test/java/org/eclipse/dataspaceconnector/core/health/HealthCheckServiceImplTest.java
+++ b/core/base/src/test/java/org/eclipse/dataspaceconnector/core/health/HealthCheckServiceImplTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.core.health;
 
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
 import org.eclipse.dataspaceconnector.spi.system.health.HealthCheckResult;
 import org.eclipse.dataspaceconnector.spi.system.health.LivenessProvider;
@@ -33,6 +34,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+@ComponentTest
 class HealthCheckServiceImplTest {
 
     private static final Duration PERIOD = Duration.ofMillis(500);

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/command/ContractNegotiationCommandQueueIntegrationTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/command/ContractNegotiationCommandQueueIntegrationTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.contract.negotiation.command;
 
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.contract.negotiation.ConsumerContractNegotiationManagerImpl;
 import org.eclipse.dataspaceconnector.contract.negotiation.ProviderContractNegotiationManagerImpl;
 import org.eclipse.dataspaceconnector.contract.negotiation.command.commands.SingleContractNegotiationCommand;
@@ -40,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ComponentTest
 class ContractNegotiationCommandQueueIntegrationTest {
 
     private final ContractNegotiationStore store = mock(ContractNegotiationStore.class);

--- a/data-protocols/ids/ids-transform-v1/build.gradle.kts
+++ b/data-protocols/ids/ids-transform-v1/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
     testImplementation(testFixtures(project(":launchers:junit")))
+    testImplementation(testFixtures(project(":common:util")))
 
 }
 

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/IdsTransformServiceExtensionTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/dataspaceconnector/ids/transform/IdsTransformServiceExtensionTest.java
@@ -20,6 +20,7 @@ import de.fraunhofer.iais.eis.Representation;
 import de.fraunhofer.iais.eis.Resource;
 import de.fraunhofer.iais.eis.ResourceCatalog;
 import de.fraunhofer.iais.eis.util.RdfResource;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.ids.spi.IdsId;
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.dataspaceconnector.ids.spi.transform.IdsTypeTransformer;
@@ -62,6 +63,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 
 @ExtendWith(DependencyInjectionExtension.class)
+@ComponentTest
 class IdsTransformServiceExtensionTest {
 
     private Map<Class<?>, List<Class<?>>> knownConvertibles;

--- a/extensions/api/control/src/test/java/org/eclipse/dataspaceconnector/api/control/ClientControlCatalogApiControllerTest.java
+++ b/extensions/api/control/src/test/java/org/eclipse/dataspaceconnector/api/control/ClientControlCatalogApiControllerTest.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.api.control;
 
 import io.restassured.RestAssured;
 import io.restassured.path.json.JsonPath;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +27,7 @@ import java.util.UUID;
 import static org.eclipse.dataspaceconnector.api.control.ControlApiServiceExtension.EDC_API_CONTROL_AUTH_APIKEY_KEY;
 import static org.eclipse.dataspaceconnector.api.control.ControlApiServiceExtension.EDC_API_CONTROL_AUTH_APIKEY_VALUE;
 
+@ComponentTest
 class ClientControlCatalogApiControllerTest extends AbstractClientControlCatalogApiControllerTest {
     private static final String CONNECTOR_ID = UUID.randomUUID().toString();
     private static final String API_KEY_HEADER = "X-Api-Key";

--- a/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/asset/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/asset/AssetApiControllerIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.asset;
 
 import io.restassured.specification.RequestSpecification;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
@@ -42,6 +43,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 
 @ExtendWith(EdcExtension.class)
+@ComponentTest
 public class AssetApiControllerIntegrationTest {
 
     private final int port = getFreePort();

--- a/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractagreement/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractagreement/ContractAgreementApiControllerIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.dataspaceconnector.api.datamanagement.contractagreement;
 
 import io.restassured.specification.RequestSpecification;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
@@ -37,6 +38,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(EdcExtension.class)
+@ComponentTest
 public class ContractAgreementApiControllerIntegrationTest {
 
     private final int port = getFreePort();

--- a/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractdefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition;
 
 import io.restassured.specification.RequestSpecification;
 import org.eclipse.dataspaceconnector.api.datamanagement.contractdefinition.model.ContractDefinitionDto;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.dataloading.ContractDefinitionLoader;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
@@ -36,6 +37,7 @@ import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.getFr
 import static org.hamcrest.Matchers.is;
 
 @ExtendWith(EdcExtension.class)
+@ComponentTest
 public class ContractDefinitionApiControllerIntegrationTest {
 
     private final int port = getFreePort();

--- a/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/contractnegotiation/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation;
 
 import io.restassured.specification.RequestSpecification;
 import org.eclipse.dataspaceconnector.api.datamanagement.contractnegotiation.model.NegotiationInitiateRequestDto;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.contract.negotiation.store.ContractNegotiationStore;
@@ -46,6 +47,7 @@ import static org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiati
 import static org.hamcrest.Matchers.is;
 
 @ExtendWith(EdcExtension.class)
+@ComponentTest
 class ContractNegotiationApiControllerIntegrationTest {
 
     private final int port = getFreePort();

--- a/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/policydefinition/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/policy/PolicyApiControllerIntegrationTest.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.api.datamanagement.policy;
 
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.contract.offer.store.ContractDefinitionStore;
@@ -36,6 +37,7 @@ import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.getFr
 import static org.hamcrest.Matchers.is;
 
 @ExtendWith(EdcExtension.class)
+@ComponentTest
 public class PolicyApiControllerIntegrationTest {
 
     private final int port = getFreePort();

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiControllerIntegrationTest.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess;
 
 import io.restassured.specification.RequestSpecification;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferRequestDto;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
@@ -38,6 +39,7 @@ import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferP
 import static org.hamcrest.Matchers.is;
 
 @ExtendWith(EdcExtension.class)
+@ComponentTest
 class TransferProcessApiControllerIntegrationTest {
 
     public static final String PROCESS_ID = "processId";

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtensionTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/TransferProcessApiExtensionTest.java
@@ -20,6 +20,7 @@ import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.T
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transform.TransferProcessTransformerTestData;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistry;
 import org.eclipse.dataspaceconnector.api.transformer.DtoTransformerRegistryImpl;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.junit.launcher.DependencyInjectionExtension;
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(DependencyInjectionExtension.class)
+@ComponentTest
 class TransferProcessApiExtensionTest {
     static Faker faker = new Faker();
     TransferProcessTransformerTestData data = new TransferProcessTransformerTestData();

--- a/extensions/api/observability/build.gradle.kts
+++ b/extensions/api/observability/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
     testImplementation(testFixtures(project(":launchers:junit")))
+    testImplementation(testFixtures(project(":common:util")))
 }
 
 publishing {

--- a/extensions/api/observability/src/test/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiExtensionTest.java
+++ b/extensions/api/observability/src/test/java/org/eclipse/dataspaceconnector/api/observability/ObservabilityApiExtensionTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.api.observability;
 
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.junit.launcher.DependencyInjectionExtension;
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -31,6 +32,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ExtendWith(DependencyInjectionExtension.class)
+@ComponentTest
 class ObservabilityApiExtensionTest {
 
     private ObservabilityApiExtension extension;

--- a/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/DataPlaneS3ExtensionTest.java
+++ b/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/DataPlaneS3ExtensionTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.aws.dataplane.s3;
 
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
@@ -25,6 +26,7 @@ import java.util.UUID;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @ExtendWith(EdcExtension.class)
+@ComponentTest
 class DataPlaneS3ExtensionTest {
 
     @Test

--- a/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/aws/data-plane-s3/src/test/java/org/eclipse/dataspaceconnector/aws/dataplane/s3/S3DataPlaneIntegrationTest.java
@@ -18,7 +18,7 @@ import com.github.javafaker.Faker;
 import org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema;
 import org.eclipse.dataspaceconnector.aws.testfixtures.AbstractS3Test;
 import org.eclipse.dataspaceconnector.aws.testfixtures.TestS3ClientProvider;
-import org.eclipse.dataspaceconnector.common.annotations.IntegrationTest;
+import org.eclipse.dataspaceconnector.aws.testfixtures.annotations.AwsS3IntegrationTest;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataFlowRequest;
@@ -39,7 +39,7 @@ import static org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema.BUCKET_N
 import static org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema.SECRET_ACCESS_KEY;
 import static org.mockito.Mockito.mock;
 
-@IntegrationTest
+@AwsS3IntegrationTest
 public class S3DataPlaneIntegrationTest extends AbstractS3Test {
 
     static Faker faker = new Faker();

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -79,7 +79,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
 
         var response = client.createDatabaseIfNotExists(DATABASE_NAME);
         database = client.getDatabase(response.getProperties().getId());
-
+        deleteDatabase();
     }
 
     @AfterAll

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -79,7 +79,6 @@ class CosmosContractNegotiationStoreIntegrationTest {
 
         var response = client.createDatabaseIfNotExists(DATABASE_NAME);
         database = client.getDatabase(response.getProperties().getId());
-        deleteDatabase();
     }
 
     @AfterAll

--- a/extensions/azure/data-plane/common/build.gradle.kts
+++ b/extensions/azure/data-plane/common/build.gradle.kts
@@ -20,3 +20,12 @@ dependencies {
     api(project(":extensions:data-plane:data-plane-spi"))
     implementation(project(":common:util"))
 }
+
+publishing {
+    publications {
+        create<MavenPublication>("data-plane-azure-common") {
+            artifactId = "data-plane-azure-common"
+            from(components["java"])
+        }
+    }
+}

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheEndToEndTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheEndToEndTest.java
@@ -22,7 +22,6 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheStore;
 import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
-import org.eclipse.dataspaceconnector.common.annotations.EndToEndTest;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheEndToEndTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/FederatedCatalogCacheEndToEndTest.java
@@ -21,6 +21,8 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheStore;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
+import org.eclipse.dataspaceconnector.common.annotations.EndToEndTest;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
@@ -44,6 +46,7 @@ import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testO
 
 
 @ExtendWith(EdcExtension.class)
+@ComponentTest
 class FederatedCatalogCacheEndToEndTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImplIntegrationTest.java
+++ b/extensions/catalog/federated-catalog-cache/src/test/java/org/eclipse/dataspaceconnector/catalog/cache/management/PartitionManagerImplIntegrationTest.java
@@ -25,6 +25,7 @@ import org.eclipse.dataspaceconnector.catalog.spi.WorkItemQueue;
 import org.eclipse.dataspaceconnector.catalog.spi.model.ExecutionPlan;
 import org.eclipse.dataspaceconnector.catalog.spi.model.UpdateRequest;
 import org.eclipse.dataspaceconnector.catalog.spi.model.UpdateResponse;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -56,6 +57,7 @@ import static org.mockito.Mockito.when;
  * This tests the PartitionManagerImpl with real crawlers and in a real multithreading environment.
  * It uses several dummy classes which are private static classes.
  */
+@ComponentTest
 class PartitionManagerImplIntegrationTest {
     public static final int WORK_ITEM_COUNT = 1000;
     private final Monitor monitorMock = mock(Monitor.class);

--- a/extensions/data-plane-selector/selector-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/DataPlaneSelectorApiExtensionTest.java
+++ b/extensions/data-plane-selector/selector-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/DataPlaneSelectorApiExtensionTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.dataplane.selector;
 
 import org.eclipse.dataspaceconnector.api.exception.mappers.EdcApiExceptionMapper;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.dataplane.selector.api.DataplaneSelectorApiController;
 import org.eclipse.dataspaceconnector.dataplane.selector.store.DataPlaneInstanceStore;
 import org.eclipse.dataspaceconnector.dataplane.selector.strategy.SelectionStrategyRegistry;
@@ -32,6 +33,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(DependencyInjectionExtension.class)
+@ComponentTest
 class DataPlaneSelectorApiExtensionTest {
     private DataPlaneSelectorApiExtension extension;
     private WebService webServiceMock;

--- a/extensions/data-plane-selector/selector-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/api/DataplaneSelectorApiControllerIntegrationTest.java
+++ b/extensions/data-plane-selector/selector-api/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/api/DataplaneSelectorApiControllerIntegrationTest.java
@@ -22,6 +22,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.eclipse.dataspaceconnector.api.exception.mappers.EdcApiExceptionMapper;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.common.testfixtures.TestUtils;
 import org.eclipse.dataspaceconnector.dataplane.selector.DataPlaneSelectorServiceImpl;
 import org.eclipse.dataspaceconnector.dataplane.selector.core.DataPlaneSelectorImpl;
@@ -54,6 +55,7 @@ import static org.eclipse.dataspaceconnector.dataplane.selector.TestFunctions.cr
 import static org.eclipse.dataspaceconnector.dataplane.selector.TestFunctions.createInstanceBuilder;
 import static org.mockito.Mockito.mock;
 
+@ComponentTest
 class DataplaneSelectorApiControllerIntegrationTest {
 
 

--- a/extensions/data-plane-selector/selector-client/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/DataPlaneInstanceClientExtensionTest.java
+++ b/extensions/data-plane-selector/selector-client/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/DataPlaneInstanceClientExtensionTest.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.dataplane.selector;
 
 import net.jodah.failsafe.RetryPolicy;
 import okhttp3.OkHttpClient;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.dataplane.selector.client.DataPlaneSelectorClient;
 import org.eclipse.dataspaceconnector.dataplane.selector.client.EmbeddedDataPlaneSelectorClient;
 import org.eclipse.dataspaceconnector.dataplane.selector.client.RemoteDataPlaneSelectorClient;
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
+@ComponentTest
 class DataPlaneInstanceClientExtensionTest {
 
     private static final String EDC_DPF_SELECTOR_URL_SETTING = "edc.dpf.selector.url";

--- a/extensions/data-plane-selector/selector-client/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/client/RemoteDataPlaneSelectorClientTest.java
+++ b/extensions/data-plane-selector/selector-client/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/client/RemoteDataPlaneSelectorClientTest.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.dataplane.selector.client;
 
 import net.jodah.failsafe.RetryPolicy;
 import org.eclipse.dataspaceconnector.api.exception.mappers.EdcApiExceptionMapper;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.common.testfixtures.TestUtils;
 import org.eclipse.dataspaceconnector.dataplane.selector.DataPlaneSelectorService;
 import org.eclipse.dataspaceconnector.dataplane.selector.api.DataplaneSelectorApiController;
@@ -45,6 +46,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ComponentTest
 class RemoteDataPlaneSelectorClientTest {
 
     private static final String BASE_URL = "http://localhost:%d/api/v1/dataplane/instances";

--- a/extensions/data-plane/data-plane-framework/build.gradle.kts
+++ b/extensions/data-plane/data-plane-framework/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     api(project(":extensions:data-plane:data-plane-spi"))
     implementation(project(":common:util"))
     testImplementation(testFixtures(project(":launchers:junit")))
+    testImplementation(testFixtures(project(":common:util")))
 }
 
 

--- a/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtensionTest.java
+++ b/extensions/data-plane/data-plane-framework/src/test/java/org/eclipse/dataspaceconnector/dataplane/framework/DataPlaneFrameworkExtensionTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.dataplane.framework;
 
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.dataplane.framework.pipeline.PipelineServiceImpl;
 import org.eclipse.dataspaceconnector.dataplane.framework.registry.TransferServiceSelectionStrategy;
 import org.eclipse.dataspaceconnector.dataplane.spi.manager.DataPlaneManager;
@@ -37,6 +38,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
+@ComponentTest
 class DataPlaneFrameworkExtensionTest {
 
     TransferService transferService1 = mock(TransferService.class);

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderProvisionerTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProviderProvisionerTest.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.Interceptor;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.policy.PolicyEngine;
@@ -38,6 +39,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ComponentTest
 class HttpProviderProvisionerTest {
     private HttpProviderProvisioner provisioner;
     private Interceptor delegate;

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.transfer.provision.http.impl;
 
 import okhttp3.Interceptor;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
@@ -53,7 +54,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith({ EdcExtension.class })
+@ExtendWith(EdcExtension.class)
+@ComponentTest
 public class HttpProvisionerExtensionEndToEndTest {
     private static final String ASSET_ID = "1";
     private static final String CONTRACT_ID = "2";

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/HttpProvisionerWebhookApiControllerIntegrationTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/HttpProvisionerWebhookApiControllerIntegrationTest.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.transfer.provision.http.webhook;
 
 import io.restassured.specification.RequestSpecification;
 import org.eclipse.dataspaceconnector.api.auth.AuthenticationService;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
@@ -43,6 +44,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThan;
 
 @ExtendWith(EdcExtension.class)
+@ComponentTest
 class HttpProvisionerWebhookApiControllerIntegrationTest {
 
     private static final String PROVISIONER_BASE_PATH = "/api/v1/provisioner";

--- a/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/HttpWebhookExtensionTest.java
+++ b/extensions/http-provisioner/src/test/java/org/eclipse/dataspaceconnector/transfer/provision/http/webhook/HttpWebhookExtensionTest.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.transfer.provision.http.webhook;
 import org.eclipse.dataspaceconnector.api.auth.AuthenticationRequestFilter;
 import org.eclipse.dataspaceconnector.api.auth.AuthenticationService;
 import org.eclipse.dataspaceconnector.api.exception.mappers.EdcApiExceptionMapper;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.junit.launcher.DependencyInjectionExtension;
 import org.eclipse.dataspaceconnector.spi.WebServer;
 import org.eclipse.dataspaceconnector.spi.WebService;
@@ -45,6 +46,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
+@ComponentTest
 class HttpWebhookExtensionTest {
 
     private HttpWebhookExtension extension;

--- a/extensions/http/jersey/src/test/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyRestServiceTest.java
+++ b/extensions/http/jersey/src/test/java/org/eclipse/dataspaceconnector/extension/jersey/JerseyRestServiceTest.java
@@ -22,6 +22,7 @@ import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.core.MediaType;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.extension.jetty.JettyConfiguration;
 import org.eclipse.dataspaceconnector.extension.jetty.JettyService;
 import org.eclipse.dataspaceconnector.extension.jetty.PortMapping;
@@ -50,6 +51,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+@ComponentTest
 public class JerseyRestServiceTest {
     private final int httpPort = getFreePort();
     private JerseyRestService jerseyRestService;

--- a/extensions/http/jetty/src/test/java/org/eclipse/dataspaceconnector/extension/jetty/JettyServiceTest.java
+++ b/extensions/http/jetty/src/test/java/org/eclipse/dataspaceconnector/extension/jetty/JettyServiceTest.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.system.configuration.ConfigFactory;
@@ -43,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 
+@ComponentTest
 class JettyServiceTest {
     private JettyService jettyService;
     private Monitor monitor;

--- a/extensions/iam/decentralized-identity/identity-did-core/build.gradle.kts
+++ b/extensions/iam/decentralized-identity/identity-did-core/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
 
     testImplementation(testFixtures(project(":extensions:iam:decentralized-identity:identity-common-test")))
     testImplementation(testFixtures(project(":launchers:junit")))
+    testImplementation(testFixtures(project(":common:util")))
 }
 
 publishing {

--- a/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtensionTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtensionTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.iam.did;
 
 import okhttp3.OkHttpClient;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.iam.did.hub.IdentityHubApiController;
 import org.eclipse.dataspaceconnector.iam.did.hub.IdentityHubClientImpl;
 import org.eclipse.dataspaceconnector.iam.did.hub.IdentityHubImpl;
@@ -41,6 +42,7 @@ import static org.mockito.Mockito.verify;
 
 
 @ExtendWith(DependencyInjectionExtension.class)
+@ComponentTest
 class IdentityDidCoreExtensionTest {
 
     private IdentityDidCoreExtension extension;

--- a/extensions/sql/pool/apache-commons-pool/build.gradle.kts
+++ b/extensions/sql/pool/apache-commons-pool/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation("org.apache.commons:commons-pool2:${apacheCommonsPool2Version}")
 
     testImplementation(testFixtures(project(":launchers:junit")))
+    testImplementation(testFixtures(project(":common:util")))
     testImplementation(project(":core:base"))
     testImplementation(project(":extensions:transaction:transaction-local"))
 

--- a/extensions/sql/pool/apache-commons-pool/src/test/java/org/eclipse/dataspaceconnector/sql/pool/commons/CommonsConnectionPoolTest.java
+++ b/extensions/sql/pool/apache-commons-pool/src/test/java/org/eclipse/dataspaceconnector/sql/pool/commons/CommonsConnectionPoolTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.sql.pool.commons;
 
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.spi.persistence.EdcPersistenceException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import javax.sql.DataSource;
 
+@ComponentTest
 class CommonsConnectionPoolTest {
 
     @Test

--- a/extensions/sql/transfer-process-store/build.gradle.kts
+++ b/extensions/sql/transfer-process-store/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
 
     testImplementation(testFixtures(project(":launchers:junit")))
     testImplementation(testFixtures(project(":extensions:sql:lease")))
+    testImplementation(testFixtures(project(":common:util")))
     testImplementation(project(":core:base"))
     testImplementation(project(":extensions:sql:pool:apache-commons-pool"))
     testImplementation(project(":extensions:transaction:transaction-local"))

--- a/extensions/transfer-functions/transfer-functions-core/src/test/java/org/eclipse/dataspaceconnector/transfer/functions/core/TransferFunctionsCoreHttpTest.java
+++ b/extensions/transfer-functions/transfer-functions-core/src/test/java/org/eclipse/dataspaceconnector/transfer/functions/core/TransferFunctionsCoreHttpTest.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.transfer.functions.core;
 import okhttp3.MediaType;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.asset.DataAddressResolver;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
@@ -47,6 +48,7 @@ import static org.mockito.Mockito.when;
 /**
  * Verifies the HTTP flow controller works.
  */
+@ComponentTest
 @ExtendWith(EdcExtension.class)
 public class TransferFunctionsCoreHttpTest {
 

--- a/samples/other/run-from-junit/build.gradle.kts
+++ b/samples/other/run-from-junit/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     testImplementation(project(":extensions:azure:vault"))
     testImplementation("com.azure:azure-storage-blob:${storageBlobVersion}")
     testImplementation(project(":extensions:in-memory:policy-store-memory"))
+    testImplementation(testFixtures(project(":common:util")))
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")

--- a/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/ConsumerRunner.java
+++ b/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/ConsumerRunner.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.junit;
 
 import org.eclipse.dataspaceconnector.aws.s3.core.S3BucketSchema;
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.ids.spi.Protocols;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
@@ -50,6 +51,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(EdcExtension.class)
+@ComponentTest
 @Disabled
 public class ConsumerRunner {
     private static final String PROVIDER_CONNECTOR = "http://localhost:8181/";

--- a/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/EndToEndTest.java
+++ b/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/EndToEndTest.java
@@ -59,6 +59,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(EdcExtension.class)
+@ComponentTest
 public class EndToEndTest {
     private static final String ASSET_ID = "test123";
     private static final String CONTRACT_ID = "contract1";

--- a/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/EndToEndTest.java
+++ b/samples/other/run-from-junit/src/test/java/org/eclipse/dataspaceconnector/junit/EndToEndTest.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.dataspaceconnector.junit;
 
+import org.eclipse.dataspaceconnector.common.annotations.ComponentTest;
 import org.eclipse.dataspaceconnector.dataloading.AssetLoader;
 import org.eclipse.dataspaceconnector.ids.spi.Protocols;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcExtension;


### PR DESCRIPTION
## What this PR changes/adds

Added test category to tests that were missing it. These are mostly component tests that use EdcExtension, run Jetty service etc.

## Further notes

This reduces UT job time from 12 minutes to 8 minutes.

## Linked Issue(s)

Relates to #223 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
