### PR TITLE
Break lease after status check

### DIFF
--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -350,9 +350,15 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
             } else {
                 // Process is not finished yet, so it stays in the IN_PROGRESS state
                 monitor.info(format("Transfer process %s not COMPLETED yet. The process will not advance to the COMPLETED state.", process.getId()));
+                breakLease(process);
                 return false;
             }
         }
+    }
+
+    private void breakLease(TransferProcess process) {
+        // Break lease
+        transferProcessStore.update(process);
     }
 
     /**
@@ -583,8 +589,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
     private boolean processConsumerRequest(TransferProcess process, DataRequest dataRequest) {
 
         if (sendRetryManager.shouldDelay(process)) {
-            // Break lease
-            transferProcessStore.update(process);
+            breakLease(process);
             return false;
         }
 

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -356,11 +356,6 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         }
     }
 
-    private void breakLease(TransferProcess process) {
-        // Break lease
-        transferProcessStore.update(process);
-    }
-
     /**
      * Process DEPROVISIONING transfer<br/>
      * Launch deprovision process. On completion, set to DEPROVISIONED if succeeded, ERROR otherwise
@@ -636,6 +631,11 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
     private void updateTransferProcess(TransferProcess transferProcess, Consumer<TransferProcessListener> observe) {
         observable.invokeForEach(observe);
         transferProcessStore.update(transferProcess);
+    }
+
+    private void breakLease(TransferProcess process) {
+        // Break lease
+        transferProcessStore.update(process);
     }
 
     public static class Builder {

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -454,7 +454,7 @@ class TransferProcessManagerImplTest {
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
 
         when(transferProcessStore.nextForState(eq(IN_PROGRESS.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(statusCheckerRegistry.resolve(anyString())).thenReturn((i, l) -> true);
+        when(statusCheckerRegistry.resolve(anyString())).thenReturn((tp, resources) -> true);
 
         var latch = countDownOnUpdateLatch();
 
@@ -473,7 +473,7 @@ class TransferProcessManagerImplTest {
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
 
         when(transferProcessStore.nextForState(eq(IN_PROGRESS.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(statusCheckerRegistry.resolve(anyString())).thenReturn((i, l) -> true);
+        when(statusCheckerRegistry.resolve(anyString())).thenReturn((tp, resources) -> true);
         var latch = countDownOnUpdateLatch();
 
         manager.start();

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -496,7 +496,7 @@ class TransferProcessManagerImplTest {
             latch.countDown();
             return List.of(process);
         });
-        when(statusCheckerRegistry.resolve(anyString())).thenReturn((i, l) -> false);
+        when(statusCheckerRegistry.resolve(anyString())).thenReturn((tp, resources) -> false);
         doThrow(new AssertionError("update() should not be called as process was not updated"))
                 .when(transferProcessStore).update(process);
 

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -504,7 +504,7 @@ class TransferProcessManagerImplTest {
 
         assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
         verify(transferProcessStore, atLeastOnce()).nextForState(anyInt(), anyInt());
-        verify(transferProcessStore).update(argThat(p -> p.getState() == IN_PROGRESS.code()));
+        verify(transferProcessStore).update(argThat(tp -> tp.getState() == IN_PROGRESS.code()));
     }
 
     @Test

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -504,7 +504,7 @@ class TransferProcessManagerImplTest {
 
         assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
         verify(transferProcessStore, atLeastOnce()).nextForState(anyInt(), anyInt());
-        verify(transferProcessStore).update(argThat(tp -> tp.getState() == IN_PROGRESS.code()));
+        verify(transferProcessStore).update(argThat(p -> p.getState() == IN_PROGRESS.code()));
     }
 
     @Test

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -484,7 +484,7 @@ class TransferProcessManagerImplTest {
     }
 
     @Test
-    @DisplayName("checkComplete: should not transition process if checker returns not yet completed")
+    @DisplayName("checkComplete: should break lease and not transition process if checker returns not yet completed")
     void verifyCompleted_notAllYetCompleted() throws InterruptedException {
         var process = createTransferProcess(IN_PROGRESS);
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
@@ -496,6 +496,7 @@ class TransferProcessManagerImplTest {
             latch.countDown();
             return List.of(process);
         });
+        when(statusCheckerRegistry.resolve(anyString())).thenReturn((i, l) -> false);
         doThrow(new AssertionError("update() should not be called as process was not updated"))
                 .when(transferProcessStore).update(process);
 
@@ -503,7 +504,7 @@ class TransferProcessManagerImplTest {
 
         assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
         verify(transferProcessStore, atLeastOnce()).nextForState(anyInt(), anyInt());
-        verify(transferProcessStore, never()).update(any());
+        verify(transferProcessStore).update(argThat(p -> p.getState() == IN_PROGRESS.code()));
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

For consumer-side transfers that are `IN_PROGRESS`, a `StatusChecker` (when provided) should execute on every `TransferProcessManagerImpl` (every 5 seconds) to check if e.g. the destination blob has been produced.

## Why it does that

Following refactoring of the lease mechanism (probably with changes in #724), when the `StatusChecker` reports that the transfer is not completed, the lease was not broken after a Status check resulting in the output being incomplete. Therefore the status checker was only run again at lease timeout (every 60 seconds).

## Further notes

## Linked Issue(s)

#236 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
