### PR TITLE
DPF Azure storage: Write ".complete" blob

### DIFF
--- a/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSink.java
+++ b/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSink.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
-import com.azure.core.credential.AzureSasCredential;
 import org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.adapter.BlobAdapterFactory;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.ParallelSink;

--- a/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSink.java
+++ b/extensions/azure/data-plane/storage/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSink.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline;
 
+import com.azure.core.credential.AzureSasCredential;
 import org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.adapter.BlobAdapterFactory;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.dataspaceconnector.dataplane.spi.pipeline.ParallelSink;
@@ -30,6 +31,9 @@ import static org.eclipse.dataspaceconnector.spi.response.ResponseStatus.ERROR_R
  * Writes data into an Azure storage container.
  */
 public class AzureStorageDataSink extends ParallelSink {
+    // Name of the empty blob used to indicate completion. Used by consumer-side status checker.
+    public static final String COMPLETE_BLOB_NAME = ".complete";
+
     private String accountName;
     private String containerName;
     private String sharedKey;
@@ -57,6 +61,18 @@ public class AzureStorageDataSink extends ParallelSink {
             }
         }
         return StatusResult.success();
+    }
+
+    @Override
+    protected StatusResult<Void> complete() {
+        try {
+            // Write an empty blob to indicate completion
+            blobAdapterFactory.getBlobAdapter(accountName, containerName, COMPLETE_BLOB_NAME, sharedKey)
+                    .getOutputStream().close();
+        } catch (Exception e) {
+            return getTransferResult(e, "Error creating blob %s on account %s", COMPLETE_BLOB_NAME, accountName);
+        }
+        return super.complete();
     }
 
     @NotNull

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureDataSourceToDataSinkTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureDataSourceToDataSinkTest.java
@@ -30,6 +30,8 @@ import java.util.concurrent.TimeUnit;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -39,6 +41,7 @@ class AzureDataSourceToDataSinkTest {
     Monitor monitor = mock(Monitor.class);
     FakeBlobAdapter fakeSource = new FakeBlobAdapter();
     FakeBlobAdapter fakeSink = new FakeBlobAdapter();
+    FakeBlobAdapter fakeCompletionMarker = new FakeBlobAdapter();
     String sourceAccountName = AzureStorageTestFixtures.createAccountName();
     String sourceContainerName = AzureStorageTestFixtures.createContainerName();
     String sourceSharedKey = AzureStorageTestFixtures.createSharedKey();
@@ -79,6 +82,12 @@ class AzureDataSourceToDataSinkTest {
                 fakeSource.name,
                 sinkSharedKey
         )).thenReturn(fakeSink);
+        when(fakeSinkFactory.getBlobAdapter(
+                eq(sinkAccountName),
+                eq(sinkContainerName),
+                argThat(name -> name.endsWith(".complete")),
+                eq(sinkSharedKey)
+        )).thenReturn(fakeCompletionMarker);
 
         var dataSink = AzureStorageDataSink.Builder.newInstance()
                 .accountName(sinkAccountName)

--- a/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSinkTest.java
+++ b/extensions/azure/data-plane/storage/src/test/java/org/eclipse/dataspaceconnector/azure/dataplane/azurestorage/pipeline/AzureStorageDataSinkTest.java
@@ -27,7 +27,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -41,6 +43,8 @@ import static org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeli
 import static org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline.AzureStorageTestFixtures.createContainerName;
 import static org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline.AzureStorageTestFixtures.createRequest;
 import static org.eclipse.dataspaceconnector.azure.dataplane.azurestorage.pipeline.AzureStorageTestFixtures.createSharedKey;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -71,8 +75,10 @@ class AzureStorageDataSinkTest {
             .monitor(monitor)
             .build();
     BlobAdapter destination = mock(BlobAdapter.class);
+    BlobAdapter completionMarker = mock(BlobAdapter.class);
     InputStreamDataSource part = new InputStreamDataSource(blobName, new ByteArrayInputStream(content.getBytes(UTF_8)));
     ByteArrayOutputStream output = new ByteArrayOutputStream();
+    OutputStream completionMarkerOutput = mock(OutputStream.class);
 
     @BeforeEach
     void setUp() {
@@ -83,6 +89,14 @@ class AzureStorageDataSinkTest {
                 blobName,
                 sharedKey))
                 .thenReturn(destination);
+
+        when(completionMarker.getOutputStream()).thenReturn(completionMarkerOutput);
+        when(blobAdapterFactory.getBlobAdapter(
+                eq(accountName),
+                eq(containerName),
+                argThat(s -> s.endsWith(".complete")),
+                eq(sharedKey)))
+                .thenReturn(completionMarker);
     }
 
     @Test
@@ -108,7 +122,6 @@ class AzureStorageDataSinkTest {
         when(destination.getOutputStream()).thenThrow(exception);
     }
 
-
     @Test
     void transferParts_whenReadFails_fails() {
         when(destination.getOutputStream()).thenThrow(exception);
@@ -126,6 +139,17 @@ class AzureStorageDataSinkTest {
         when(part.openStream()).thenReturn(input);
         when(part.name()).thenReturn(blobName);
         assertThatTransferPartsFails(part, "Error transferring blob for %s on account %s", blobName, accountName);
+    }
+
+    @Test
+    void complete() throws IOException {
+        dataSink.complete();
+        verify(blobAdapterFactory).getBlobAdapter(
+                eq(accountName),
+                eq(containerName),
+                argThat(s -> s.endsWith(".complete")),
+                eq(sharedKey));
+        verify(completionMarkerOutput).close();
     }
 
     private void assertThatTransferPartsFails(Part part, String logMessage, Object... args) {

--- a/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSink.java
+++ b/extensions/data-plane/data-plane-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSink.java
@@ -49,7 +49,7 @@ public abstract class ParallelSink implements DataSink {
                             .filter(AbstractResult::failed)
                             .findFirst()
                             .map(r -> StatusResult.<Void>failure(ERROR_RETRY, String.join(",", r.getFailureMessages())))
-                            .orElseGet(StatusResult::success))
+                            .orElseGet(this::complete))
                     .exceptionally(throwable -> StatusResult.failure(ERROR_RETRY, "Unhandled exception raised when transferring data: " + throwable.getMessage()));
         } catch (Exception e) {
             monitor.severe("Error processing data transfer request: " + requestId, e);
@@ -58,6 +58,10 @@ public abstract class ParallelSink implements DataSink {
     }
 
     protected abstract StatusResult<Void> transferParts(List<DataSource.Part> parts);
+
+    protected StatusResult<Void> complete() {
+        return StatusResult.success();
+    }
 
     protected abstract static class Builder<B extends Builder<B, T>, T extends ParallelSink> {
         protected T sink;

--- a/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSinkTest.java
+++ b/extensions/data-plane/data-plane-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/spi/pipeline/ParallelSinkTest.java
@@ -41,6 +41,9 @@ class ParallelSinkTest {
     String dataSourceName = faker.lorem().word();
     String dataSourceContent = faker.lorem().characters();
     String errorMessage = faker.lorem().sentence();
+    InputStreamDataSource dataSource = new InputStreamDataSource(
+            dataSourceName,
+            new ByteArrayInputStream(dataSourceContent.getBytes()));
 
     FakeParallelSink fakeSink;
 
@@ -54,12 +57,18 @@ class ParallelSinkTest {
 
     @Test
     void transfer_succeeds() {
-        var dataSource = new InputStreamDataSource(dataSourceName, new ByteArrayInputStream(dataSourceContent.getBytes()));
-
         assertThat(fakeSink.transfer(dataSource)).succeedsWithin(500, TimeUnit.MILLISECONDS)
                 .satisfies(transferResult -> assertThat(transferResult.succeeded()).isTrue());
 
         assertThat(fakeSink.parts).containsExactly(dataSource);
+        assertThat(fakeSink.complete).isEqualTo(1);
+    }
+
+    @Test
+    void transfer_whenCompleteFails_fails() {
+        fakeSink.completeResponse = StatusResult.failure(ResponseStatus.ERROR_RETRY);
+        assertThat(fakeSink.transfer(dataSource)).succeedsWithin(500, TimeUnit.MILLISECONDS)
+                .isEqualTo(fakeSink.completeResponse);
     }
 
     @Test
@@ -69,8 +78,9 @@ class ParallelSinkTest {
         when(dataSourceMock.openPartStream()).thenThrow(new RuntimeException(errorMessage));
 
         assertThat(fakeSink.transfer(dataSourceMock)).succeedsWithin(500, TimeUnit.MILLISECONDS)
-            .satisfies(transferResult -> assertThat(transferResult.failed()).isTrue())
-            .satisfies(transferResult -> assertThat(transferResult.getFailureMessages()).containsExactly("Error processing data transfer request"));
+                .satisfies(transferResult -> assertThat(transferResult.failed()).isTrue())
+                .satisfies(transferResult -> assertThat(transferResult.getFailureMessages()).containsExactly("Error processing data transfer request"));
+        assertThat(fakeSink.complete).isEqualTo(0);
     }
 
     @Test
@@ -80,11 +90,12 @@ class ParallelSinkTest {
         var dataSource = new InputStreamDataSource(dataSourceName, new ByteArrayInputStream(dataSourceContent.getBytes()));
 
         assertThat(fakeSink.transfer(dataSource)).succeedsWithin(500, TimeUnit.MILLISECONDS)
-            .satisfies(transferResult -> assertThat(transferResult.failed()).isTrue())
+                .satisfies(transferResult -> assertThat(transferResult.failed()).isTrue())
                 .satisfies(transferResult -> assertThat(transferResult.getFailure().status()).isEqualTo(ResponseStatus.ERROR_RETRY))
-            .satisfies(transferResult -> assertThat(transferResult.getFailureMessages()).containsExactly(errorMessage));
+                .satisfies(transferResult -> assertThat(transferResult.getFailureMessages()).containsExactly(errorMessage));
 
         assertThat(fakeSink.parts).containsExactly(dataSource);
+        assertThat(fakeSink.complete).isEqualTo(0);
     }
 
     @Test
@@ -101,17 +112,26 @@ class ParallelSinkTest {
                         .containsExactly("Unhandled exception raised when transferring data: java.lang.RuntimeException: " + errorMessage));
 
         assertThat(fakeSink.parts).containsExactly(dataSource);
+        assertThat(fakeSink.complete).isEqualTo(0);
     }
 
     private static class FakeParallelSink extends ParallelSink {
 
         List<DataSource.Part> parts;
         Supplier<StatusResult<Void>> transferResultSupplier = StatusResult::success;
+        private int complete;
+        private StatusResult<Void> completeResponse = StatusResult.success();
 
         @Override
         protected StatusResult<Void> transferParts(List<DataSource.Part> parts) {
             this.parts = parts;
             return transferResultSupplier.get();
+        }
+
+        @Override
+        protected StatusResult<Void> complete() {
+            complete++;
+            return completeResponse;
         }
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

AzureStorageDataSink writes a blob named `.complete` after all parts are transferred

## Why it does that

End-to-end flow for blob storage transfers across EDC and DPF is not working (#231). This is one of multiple PRs to solve several issues causing the problem.

When a data transfer target is an Azure Storage container, the consumer did not detect transfer completion. 

`ObjectContainerStatusChecker` polls for a blob called `*.complete` in the destination storage container to determine if a transfer has completed on the provider side. As `AzureStorageDataSink` did not currently write this file, transfer completion was never detected.

## Further notes


## Linked Issue(s)

#239 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
