### PR TITLE
TransferProcess API: provide provisioned resource information

### DIFF
--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferProcessDto.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferProcessDto.java
@@ -18,6 +18,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import java.util.Map;
+
 @JsonDeserialize(builder = TransferProcessDto.Builder.class)
 public class TransferProcessDto {
     private String id;
@@ -25,6 +27,7 @@ public class TransferProcessDto {
     private String state;
     private String errorDetail;
     private DataRequestDto dataRequest;
+    private Map<String, String> dataDestination = Map.of();
 
     private TransferProcessDto() {
     }
@@ -47,6 +50,10 @@ public class TransferProcessDto {
 
     public DataRequestDto getDataRequest() {
         return dataRequest;
+    }
+
+    public Map<String, String> getDataDestination() {
+        return dataDestination;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -84,6 +91,11 @@ public class TransferProcessDto {
 
         public Builder dataRequest(DataRequestDto dataRequest) {
             transferProcessDto.dataRequest = dataRequest;
+            return this;
+        }
+
+        public Builder dataDestination(Map<String, String> dataDestination) {
+            transferProcessDto.dataDestination = Map.copyOf(dataDestination);
             return this;
         }
 

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
@@ -42,16 +42,12 @@ public class TransferProcessToTransferProcessDtoTransformer implements DtoTransf
         if (object == null) {
             return null;
         }
-        var dataRequest = object.getDataRequest();
-        var dataDestination = dataRequest != null && dataRequest.getDataDestination() != null ?
-                        dataRequest.getDataDestination().getProperties() :
-                        Map.<String, String>of();
         return TransferProcessDto.Builder.newInstance()
                 .id(object.getId())
                 .type(object.getType().name())
                 .state(getState(object.getState(), context))
                 .errorDetail(object.getErrorDetail())
-                .dataDestination(dataDestination)
+                .dataDestination(object.getDataRequest().getDataDestination().getProperties())
                 .dataRequest(context.transform(object.getDataRequest(), DataRequestDto.class))
                 .build();
     }

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
@@ -23,8 +23,6 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessS
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Map;
-
 public class TransferProcessToTransferProcessDtoTransformer implements DtoTransformer<TransferProcess, TransferProcessDto> {
 
     @Override

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
@@ -23,6 +23,8 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessS
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
+
 public class TransferProcessToTransferProcessDtoTransformer implements DtoTransformer<TransferProcess, TransferProcessDto> {
 
     @Override
@@ -40,11 +42,16 @@ public class TransferProcessToTransferProcessDtoTransformer implements DtoTransf
         if (object == null) {
             return null;
         }
+        var dataRequest = object.getDataRequest();
+        var dataDestination = dataRequest != null && dataRequest.getDataDestination() != null ?
+                        dataRequest.getDataDestination().getProperties() :
+                        Map.<String, String>of();
         return TransferProcessDto.Builder.newInstance()
                 .id(object.getId())
                 .type(object.getType().name())
                 .state(getState(object.getState(), context))
                 .errorDetail(object.getErrorDetail())
+                .dataDestination(dataDestination)
                 .dataRequest(context.transform(object.getDataRequest(), DataRequestDto.class))
                 .build();
     }

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformerTest.java
@@ -17,14 +17,18 @@ package org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.transf
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.DataRequestDto;
 import org.eclipse.dataspaceconnector.api.datamanagement.transferprocess.model.TransferProcessDto;
 import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.UNSAVED;
 import static org.mockito.Mockito.when;
 
 class TransferProcessToTransferProcessDtoTransformerTest {
@@ -53,6 +57,25 @@ class TransferProcessToTransferProcessDtoTransformerTest {
         data.entity.state(invalidStateCode());
         data.dto.state(null);
         problems.add("Invalid value for TransferProcess.state");
+
+        assertThatEntityTransformsToDto();
+    }
+
+    @Test
+    void transform_whenMinimalData() {
+        data.dto.state(UNSAVED.name());
+
+        data.dataDestination = DataAddress.Builder.newInstance().type(data.dataDestinationType);
+        data.dataRequest = DataRequest.Builder.newInstance()
+                .dataDestination(data.dataDestination.build())
+                .build();
+        data.entity = TransferProcess.Builder.newInstance()
+                .id(data.id)
+                .type(data.type)
+                .dataRequest(data.dataRequest);
+        data.dto
+                .dataDestination(Map.of("type", data.dataDestinationType))
+                .errorDetail(null);
 
         assertThatEntityTransformsToDto();
     }

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessTransformerTestData.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessTransformerTestData.java
@@ -40,9 +40,9 @@ public class TransferProcessTransformerTestData {
     TransferProcessStates state = faker.options().option(TransferProcessStates.class);
     String errorDetail = faker.lorem().word();
 
-    private Map<String, String> dataDestinationProperties = Map.of(faker.lorem().word(), faker.lorem().word());
-    private final String dataDestinationType = faker.lorem().word();
-    private final DataAddress.Builder dataDestination = DataAddress.Builder.newInstance().type(dataDestinationType).properties(dataDestinationProperties);
+    Map<String, String> dataDestinationProperties = Map.of(faker.lorem().word(), faker.lorem().word());
+    String dataDestinationType = faker.lorem().word();
+    DataAddress.Builder dataDestination = DataAddress.Builder.newInstance().type(dataDestinationType).properties(dataDestinationProperties);
     DataRequest dataRequest = DataRequest.Builder.newInstance()
             .dataDestination(dataDestination.build())
             .build();

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessTransformerTestData.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessTransformerTestData.java
@@ -25,6 +25,9 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.mockito.Mockito.mock;
 
 public class TransferProcessTransformerTestData {
@@ -37,8 +40,11 @@ public class TransferProcessTransformerTestData {
     TransferProcessStates state = faker.options().option(TransferProcessStates.class);
     String errorDetail = faker.lorem().word();
 
+    private Map<String, String> dataDestinationProperties = Map.of(faker.lorem().word(), faker.lorem().word());
+    private final String dataDestinationType = faker.lorem().word();
+    private final DataAddress.Builder dataDestination = DataAddress.Builder.newInstance().type(dataDestinationType).properties(dataDestinationProperties);
     DataRequest dataRequest = DataRequest.Builder.newInstance()
-            .dataDestination(DataAddress.Builder.newInstance().type(faker.lorem().word()).build())
+            .dataDestination(dataDestination.build())
             .build();
     DataRequestDto dataRequestDto = DataRequestDto.Builder.newInstance().build();
 
@@ -54,5 +60,12 @@ public class TransferProcessTransformerTestData {
             .type(type.name())
             .state(state.name())
             .errorDetail(errorDetail)
-            .dataRequest(dataRequestDto);
+            .dataRequest(dataRequestDto)
+            .dataDestination(mapWith(dataDestinationProperties, "type", dataDestinationType));
+
+    private Map<String, String> mapWith(Map<String, String> sourceMap, String key, String value) {
+        var newMap = new HashMap<>(sourceMap);
+        newMap.put(key, value);
+        return newMap;
+    }
 }

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -9,11 +9,73 @@ info:
 servers:
 - url: /
 paths:
-  /assets:
+  /catalog:
+    post:
+      operationId: getCatalog
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FederatedCatalogCacheQuery'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractOffer'
+  /instances:
     get:
       tags:
-      - Asset
-      operationId: getAllAssets
+      - Dataplane Selector
+      operationId: getAll
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataPlaneInstance'
+    post:
+      tags:
+      - Dataplane Selector
+      operationId: addEntry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataPlaneInstance'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /instances/select:
+    post:
+      tags:
+      - Dataplane Selector
+      operationId: find
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SelectionRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataPlaneInstance'
+  /policies:
+    get:
+      tags:
+      - Policy
+      operationId: getAllPolicies
       parameters:
       - name: offset
         in: query
@@ -63,26 +125,26 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AssetDto'
+                  $ref: '#/components/schemas/Policy'
     post:
       tags:
-      - Asset
-      operationId: createAsset
+      - Policy
+      operationId: createPolicy
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AssetEntryDto'
+              $ref: '#/components/schemas/Policy'
       responses:
         default:
           description: default response
           content:
             '*/*': {}
-  /assets/{id}:
+  /policies/{id}:
     get:
       tags:
-      - Asset
-      operationId: getAsset
+      - Policy
+      operationId: getPolicy
       parameters:
       - name: id
         in: path
@@ -97,11 +159,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AssetDto'
+                $ref: '#/components/schemas/Policy'
     delete:
       tags:
-      - Asset
-      operationId: removeAsset
+      - Policy
+      operationId: deletePolicy
       parameters:
       - name: id
         in: path
@@ -115,102 +177,6 @@ paths:
           description: default response
           content:
             '*/*': {}
-  /control/catalog:
-    get:
-      operationId: getDescription
-      parameters:
-      - name: provider
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-      deprecated: true
-  /control/transfer:
-    post:
-      operationId: addTransfer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DataRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-      deprecated: true
-  /control/agreement/{id}:
-    get:
-      operationId: getAgreementById
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-      deprecated: true
-  /control/negotiation/{id}:
-    get:
-      operationId: getNegotiationById
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-      deprecated: true
-  /control/negotiation/{id}/state:
-    get:
-      operationId: getNegotiationStateById
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-      deprecated: true
-  /control/negotiation:
-    post:
-      operationId: initiateNegotiation
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ContractOfferRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-      deprecated: true
   /check/health:
     get:
       tags:
@@ -251,70 +217,6 @@ paths:
           description: default response
           content:
             application/json: {}
-  /instances:
-    get:
-      tags:
-      - Dataplane Selector
-      operationId: getAll
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DataPlaneInstance'
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: addEntry
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DataPlaneInstance'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /instances/select:
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: find
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SelectionRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DataPlaneInstance'
-  /catalog:
-    get:
-      tags:
-      - Catalog
-      operationId: getCatalog
-      parameters:
-      - name: providerUrl
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Catalog'
   /contractnegotiations/{id}/cancel:
     post:
       tags:
@@ -482,52 +384,153 @@ paths:
             text/plain:
               schema:
                 type: string
-  /callback/{processId}/deprovision:
+  /transferprocess/{id}/cancel:
     post:
       tags:
-      - HTTP Provisioner Webhook
-      operationId: callDeprovisionWebhook
+      - Transfer Process
+      operationId: cancelTransferProcess
       parameters:
-      - name: processId
+      - name: id
         in: path
         required: true
         style: simple
         explode: false
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DeprovisionedResource'
       responses:
         default:
           description: default response
           content:
-            application/json: {}
-  /callback/{processId}/provision:
+            '*/*': {}
+  /transferprocess/{id}/deprovision:
     post:
       tags:
-      - HTTP Provisioner Webhook
-      operationId: callProvisionWebhook
+      - Transfer Process
+      operationId: deprovisionTransferProcess
       parameters:
-      - name: processId
+      - name: id
         in: path
         required: true
         style: simple
         explode: false
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ProvisionerWebhookRequest'
       responses:
         default:
           description: default response
           content:
-            application/json: {}
+            '*/*': {}
+  /transferprocess:
+    get:
+      tags:
+      - Transfer Process
+      operationId: getAllTransferProcesses
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TransferProcessDto'
+    post:
+      tags:
+      - Transfer Process
+      operationId: initiateTransfer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransferRequestDto'
+      responses:
+        default:
+          description: default response
+          content:
+            text/plain:
+              schema:
+                type: string
+  /transferprocess/{id}:
+    get:
+      tags:
+      - Transfer Process
+      operationId: getTransferProcess
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransferProcessDto'
+  /transferprocess/{id}/state:
+    get:
+      tags:
+      - Transfer Process
+      operationId: getTransferProcessState
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            text/plain:
+              schema:
+                type: string
   /contractdefinitions:
     get:
       tags:
@@ -702,11 +705,11 @@ paths:
           description: default response
           content:
             application/json: {}
-  /policies:
+  /assets:
     get:
       tags:
-      - Policy
-      operationId: getAllPolicies
+      - Asset
+      operationId: getAllAssets
       parameters:
       - name: offset
         in: query
@@ -756,26 +759,26 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Policy'
+                  $ref: '#/components/schemas/AssetDto'
     post:
       tags:
-      - Policy
-      operationId: createPolicy
+      - Asset
+      operationId: createAsset
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Policy'
+              $ref: '#/components/schemas/AssetEntryDto'
       responses:
         default:
           description: default response
           content:
             '*/*': {}
-  /policies/{id}:
+  /assets/{id}:
     get:
       tags:
-      - Policy
-      operationId: getPolicy
+      - Asset
+      operationId: getAsset
       parameters:
       - name: id
         in: path
@@ -790,11 +793,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Policy'
+                $ref: '#/components/schemas/AssetDto'
     delete:
       tags:
-      - Policy
-      operationId: deletePolicy
+      - Asset
+      operationId: removeAsset
       parameters:
       - name: id
         in: path
@@ -883,118 +886,86 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ContractAgreementDto'
-  /transferprocess/{id}/cancel:
+  /callback/{processId}/deprovision:
     post:
       tags:
-      - Transfer Process
-      operationId: cancelTransferProcess
+      - HTTP Provisioner Webhook
+      operationId: callDeprovisionWebhook
       parameters:
-      - name: id
+      - name: processId
         in: path
         required: true
         style: simple
         explode: false
         schema:
           type: string
-      responses:
-        default:
-          description: default response
-          content:
-            '*/*': {}
-  /transferprocess/{id}/deprovision:
-    post:
-      tags:
-      - Transfer Process
-      operationId: deprovisionTransferProcess
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            '*/*': {}
-  /transferprocess:
-    get:
-      tags:
-      - Transfer Process
-      operationId: getAllTransferProcesses
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/TransferProcessDto'
-    post:
-      tags:
-      - Transfer Process
-      operationId: initiateTransfer
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TransferRequestDto'
+              $ref: '#/components/schemas/DeprovisionedResource'
       responses:
         default:
           description: default response
           content:
-            text/plain:
-              schema:
-                type: string
-  /transferprocess/{id}:
-    get:
+            application/json: {}
+  /callback/{processId}/provision:
+    post:
       tags:
-      - Transfer Process
-      operationId: getTransferProcess
+      - HTTP Provisioner Webhook
+      operationId: callProvisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionerWebhookRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /control/catalog:
+    get:
+      operationId: getDescription
+      parameters:
+      - name: provider
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      deprecated: true
+  /control/transfer:
+    post:
+      operationId: addTransfer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      deprecated: true
+  /control/agreement/{id}:
+    get:
+      operationId: getAgreementById
       parameters:
       - name: id
         in: path
@@ -1007,14 +978,11 @@ paths:
         default:
           description: default response
           content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TransferProcessDto'
-  /transferprocess/{id}/state:
+            application/json: {}
+      deprecated: true
+  /control/negotiation/{id}:
     get:
-      tags:
-      - Transfer Process
-      operationId: getTransferProcessState
+      operationId: getNegotiationById
       parameters:
       - name: id
         in: path
@@ -1027,9 +995,39 @@ paths:
         default:
           description: default response
           content:
-            text/plain:
-              schema:
-                type: string
+            application/json: {}
+      deprecated: true
+  /control/negotiation/{id}/state:
+    get:
+      operationId: getNegotiationStateById
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      deprecated: true
+  /control/negotiation:
+    post:
+      operationId: initiateNegotiation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ContractOfferRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      deprecated: true
 components:
   schemas:
     Action:
@@ -1434,10 +1432,16 @@ components:
           type: string
         dataRequest:
           $ref: '#/components/schemas/DataRequestDto'
+        dataDestination:
+          type: object
+          additionalProperties:
+            type: string
     TransferRequestDto:
       type: object
       properties:
         connectorAddress:
+          type: string
+        id:
           type: string
         contractId:
           type: string

--- a/resources/openapi/yaml/transferprocess.yaml
+++ b/resources/openapi/yaml/transferprocess.yaml
@@ -148,6 +148,10 @@ components:
           type: string
         dataRequest:
           $ref: '#/components/schemas/DataRequestDto'
+        dataDestination:
+          type: object
+          additionalProperties:
+            type: string
     DataAddress:
       type: object
       properties:
@@ -159,6 +163,8 @@ components:
       type: object
       properties:
         connectorAddress:
+          type: string
+        id:
           type: string
         contractId:
           type: string


### PR DESCRIPTION
## What this PR changes/adds

Provide DataManagement API client information about data destination properties, such as the automatically provisioned Azure storage container name when `managedResources=true`.

## Why it does that

When performing a transfer to Azure blob with `managedResources=true`, the consumer EDC provisions a storage container with a randomly generated name. The container is used as destination of the data copy on the provider DPF.

The client polls the TransferProcess API for completion. When the transfer is completed, the client can access the data in the storage container. However, the client currently had no way of knowing what storage container was created by the consumer provisioner. 

When using a blob storage provisioned account, the `dataDestination` will look like

```
{HashMap@15791}  size = 4
 "container" -> "7162210a-5ee9-4f43-8443-7a104c4d15fc"
 "keyName" -> "resource"
 "type" -> "AzureStorage"
 "account" -> "account2"
```

## Further notes

This is required for building system tests that verify actual data has been written. It can also be used e.g. by web app clients to generate download links.

Added a `transform_whenMinimalData` UT case to ensure no NPE when missing custom DataDestination properties and the like.

## Linked Issue(s)

#237 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
