### PR TITLE
CD: Include component tests coverage in codecov code coverage report.

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -17,5 +17,5 @@ runs:
       with:
         name: Test Results ${{ github.job }}
         path: |
-          "**/test-results/**/*.xml"
-          "**/build/reports/jacoco/test/jacocoTestReport.xml"
+          **/test-results/**/*.xml
+          **/build/reports/jacoco/test/jacocoTestReport.xml

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -16,4 +16,6 @@ runs:
       if: always()
       with:
         name: Test Results ${{ github.job }}
-        path: "**/test-results/**/*.xml"
+        path: |
+          "**/test-results/**/*.xml"
+          "**/build/reports/jacoco/test/jacocoTestReport.xml"

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -373,6 +373,8 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
+      # Sources are need for Codecov report.
+      - uses: actions/checkout@v2
       - name: Download Artifacts
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -390,7 +390,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      # Sources are needed for Codecov report.
+      # Sources are needed for Codecov report
       - uses: actions/checkout@v2
       - name: Download Artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -324,6 +324,8 @@ jobs:
           path: '**/build/reports/gatling/**'
 
   Component-Tests:
+    env:
+      JACOCO: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -337,7 +339,7 @@ jobs:
       - name: Component Tests
         uses: ./.github/actions/run-tests
         with:
-          command: ./gradlew test -DincludeTags="ComponentTest"
+          command: ./gradlew test -DincludeTags="ComponentTest" jacocoTestReport
 
   OpenTelemetry-Integration-Tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -373,8 +373,6 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      # Sources are need for Codecov report.
-      - uses: actions/checkout@v2
       - name: Download Artifacts
         uses: actions/download-artifact@v2
         with:
@@ -384,5 +382,19 @@ jobs:
         if: always()
         with:
           files: "**/test-results/**/*.xml"
+
+  Upload-Coverage-Report-To-Codecov:
+    needs:
+      - Unit-Tests
+      - Component-Tests
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      # Sources are need for Codecov report.
+      - uses: actions/checkout@v2
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
       - name: CodeCov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -339,7 +339,7 @@ jobs:
       - name: Component Tests
         uses: ./.github/actions/run-tests
         with:
-          command: ./gradlew test -DincludeTags="ComponentTest" jacocoTestReport
+          command: ./gradlew test jacocoTestReport -DincludeTags="ComponentTest"
 
   OpenTelemetry-Integration-Tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -390,7 +390,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      # Sources are need for Codecov report.
+      # Sources are needed for Codecov report.
       - uses: actions/checkout@v2
       - name: Download Artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -67,9 +67,6 @@ jobs:
         with:
           command: ./gradlew test jacocoTestReport
 
-      - name: CodeCov
-        uses: codecov/codecov-action@v2
-
   Sanity-Check:
     runs-on: ubuntu-latest
     steps:
@@ -383,3 +380,5 @@ jobs:
         if: always()
         with:
           files: "**/test-results/**/*.xml"
+      - name: CodeCov
+        uses: codecov/codecov-action@v2


### PR DESCRIPTION
## What this PR changes/adds

Include ComponentTests to code coverage report.
In the current state, only unit tests are included in the code coverage report. This PR also includes the Component Tests to the report.

- Publish jacoco reports for each run-tests action. jacoco reports will be a published artifact. The report will be present only for unit tests and component tests because the jacocoTestReport task is only running for unit tests and component tests.
- Run jacocoTestReport task for ComponentTest
- Created a job to publish the code coverage report (downloading the artifacts containing the jacoco reports first).

We can see that test coverage increased after including the ComponentTests: 
https://codecov.io/github/agera-edc/DataSpaceConnector/commit/93f09d5d7c8dbbd1af763ce26300af0b611f37d4

## Linked Issue(s)

#230 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
