### PR TITLE
[Spike] OpenAPI rest client

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,18 +69,20 @@ buildscript {
 
 allprojects {
     apply(plugin = "maven-publish")
-    apply(plugin = "checkstyle")
+    if (!project.name.endsWith("rest-client")) {
+        apply(plugin = "checkstyle")
+        checkstyle {
+            toolVersion = "9.0"
+            configFile = rootProject.file("resources/edc-checkstyle-config.xml")
+            maxErrors = 0 // does not tolerate errors
+        }
+
+    }
     apply(plugin = "java")
     apply(plugin = "org.eclipse.dataspaceconnector.test-summary")
 
     if (System.getenv("JACOCO") == "true") {
         apply(plugin = "jacoco")
-    }
-
-    checkstyle {
-        toolVersion = "9.0"
-        configFile = rootProject.file("resources/edc-checkstyle-config.xml")
-        maxErrors = 0 // does not tolerate errors
     }
 
     java {

--- a/common/rest-client/build.gradle.kts
+++ b/common/rest-client/build.gradle.kts
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+// https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-gradle-plugin
+// https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/java.md
+
+
+var jakarta_annotation_version: String = "1.3.5"
+
+plugins {
+    java
+    id("org.openapi.generator") version "5.4.0"
+}
+
+apply(plugin = "org.openapi.generator")
+
+tasks.withType(org.openapitools.generator.gradle.plugin.tasks.GenerateTask::class.java) {
+    generatorName.value("java")
+    inputSpec.value(file("$rootDir/resources/openapi/openapi.yaml").getAbsolutePath())
+    validateSpec.value(false)
+    configOptions.set(
+        mapOf(
+            "invokerPackage" to "org.eclipse.dataspaceconnector.client",
+            "apiPackage" to "org.eclipse.dataspaceconnector.client.api",
+            "modelPackage" to "org.eclipse.dataspaceconnector.client.models",
+        )
+    )
+}
+
+// compileJava.dependsOn tasks.openApiGenerate
+val compileJava: JavaCompile by tasks
+val openApiGenerate: org.openapitools.generator.gradle.plugin.tasks.GenerateTask by tasks
+compileJava.apply {
+    dependsOn(openApiGenerate)
+}
+sourceSets {
+    main {
+        java {
+            srcDirs(
+                "$buildDir/generate-resources/main/src/main/java"
+            )
+        }
+    }
+}
+
+dependencies {
+    // dependencies copied from build/generate-resources/main/build.gradle
+    implementation("io.swagger:swagger-annotations:1.5.24")
+    implementation("com.google.code.findbugs:jsr305:3.0.2")
+    implementation("com.squareup.okhttp3:okhttp:4.9.1")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.9.1")
+    implementation("com.google.code.gson:gson:2.8.6")
+    implementation("io.gsonfire:gson-fire:1.8.4")
+    implementation("org.openapitools:jackson-databind-nullable:0.2.1")
+    implementation("org.apache.commons:commons-lang3:3.10")
+    implementation("org.threeten:threetenbp:1.4.3")
+    implementation("jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version")
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("rest-client") {
+            artifactId = "rest-client"
+            from(components["java"])
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ include(":common:util")
 include(":common:state-machine-lib")
 include(":common:token-generation-lib")
 include(":common:token-validation-lib")
+include(":common:rest-client")
 
 
 // EDC core modules

--- a/system-tests/e2e-transfer-test/runner/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/runner/build.gradle.kts
@@ -23,6 +23,7 @@ val awaitility: String by project
 val assertj: String by project
 
 dependencies {
+    testImplementation(project(":common:rest-client"))
     testImplementation(testFixtures(project(":common:util")))
     testImplementation(testFixtures(project(":launchers:junit")))
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/EndToEndTransferTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/EndToEndTransferTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspaceconnector.test.e2e;
 
+import org.eclipse.dataspaceconnector.client.ApiException;
 import org.eclipse.dataspaceconnector.common.annotations.EndToEndTest;
 import org.eclipse.dataspaceconnector.junit.launcher.EdcRuntimeExtension;
 import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
@@ -90,7 +91,7 @@ class EndToEndTransferTest {
     );
 
     @Test
-    void httpPullDataTransfer() {
+    void httpPullDataTransfer() throws ApiException {
         createAssetAndContractDefinitionOnProvider();
 
         var catalog = CONSUMER.getCatalog(PROVIDER.idsEndpoint());
@@ -121,7 +122,7 @@ class EndToEndTransferTest {
     }
 
     @Test
-    void httpPushDataTransfer() {
+    void httpPushDataTransfer() throws ApiException {
         PROVIDER.registerDataPlane();
         createAssetAndContractDefinitionOnProvider();
 
@@ -157,7 +158,7 @@ class EndToEndTransferTest {
         });
     }
 
-    private void createAssetAndContractDefinitionOnProvider() {
+    private void createAssetAndContractDefinitionOnProvider() throws ApiException {
         var assetId = "asset-id";
         PROVIDER.createAsset(assetId);
         var policyId = PROVIDER.createPolicy(assetId);

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/Participant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/dataspaceconnector/test/e2e/Participant.java
@@ -14,6 +14,12 @@
 
 package org.eclipse.dataspaceconnector.test.e2e;
 
+import org.eclipse.dataspaceconnector.client.ApiClient;
+import org.eclipse.dataspaceconnector.client.ApiException;
+import org.eclipse.dataspaceconnector.client.api.AssetApi;
+import org.eclipse.dataspaceconnector.client.models.AssetDto;
+import org.eclipse.dataspaceconnector.client.models.AssetEntryDto;
+import org.eclipse.dataspaceconnector.client.models.DataAddressDto;
 import org.eclipse.dataspaceconnector.policy.model.Action;
 import org.eclipse.dataspaceconnector.policy.model.Permission;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
@@ -53,33 +59,22 @@ public class Participant {
     private final URI backendService = URI.create("http://localhost:" + getFreePort());
     private final URI idsEndpoint = URI.create("http://localhost:" + getFreePort());
 
-    public void createAsset(String assetId) {
-        var asset = Map.of(
-                "asset", Map.of(
-                        "properties", Map.of(
-                                "asset:prop:id", assetId,
-                                "asset:prop:name", "asset name",
-                                "asset:prop:contenttype", "text/plain",
-                                "asset:prop:policy-id", "use-eu"
-                        )
-                ),
-                "dataAddress", Map.of(
-                        "properties", Map.of(
+    public void createAsset(String assetId) throws ApiException {
+        var apiClient = new ApiClient().setBasePath(controlPlane.toString() + "/api");
+        AssetEntryDto dto = new AssetEntryDto()
+                .asset(new AssetDto().properties(Map.of(
+                        "asset:prop:id", assetId,
+                        "asset:prop:name", "asset name",
+                        "asset:prop:contenttype", "text/plain",
+                        "asset:prop:policy-id", "use-eu"
+                )))
+                .dataAddress(new DataAddressDto()
+                        .properties(Map.of(
                                 "name", "data",
                                 "endpoint", backendService + "/api/service",
                                 "type", "HttpData"
-                        )
-                )
-        );
-
-        given()
-                .baseUri(controlPlane.toString())
-                .contentType(JSON)
-                .body(asset)
-                .when()
-                .post("/api/assets")
-                .then()
-                .statusCode(204);
+                        )));
+        new AssetApi(apiClient).createAsset(dto);
     }
 
     public String createPolicy(String assetId) {


### PR DESCRIPTION
This spike illustrates using a generated REST client.

Relates to https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/1205

## Objectives

- Develop a REST client module with generated code from the OpenAPI definition, and use it in system tests
- Reduce the verbosity, increase the maintainability and improve the clarity of system tests
- Ensure the scope of system tests is not integration testing of the controllers, that can be done in specific RestAssured tests
- Provide a client module in Maven that can be directly used by end users running on JVM
- Dogfood our OpenAPI definition

## Results

- The `org.openapi.generator` [plugin](https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-gradle-plugin) appears to work reliably as part of the build, and is fast (8 seconds).

- The plugin generates an entire gradle project in the build/ directory. We have the option:
   - Running the plugin manually and committing the files we want, as we are doing for the OpenAPI definition.
   - Run the plugin as part of every build, and simply add the generated `src/main/java` folder to the source set.

  Since the execution is fast, we opted for the latter option here.

- In EDC, we standardise on OkHttpClient and Jackson. The plugin can use various HTTP client libraries and JSON serialisation frameworks. If generating for OkHttpClient, only GSON serialisation can be used. This means that new generated DTO classes must be used on the client side.

  The generated DTO classes are mutable, and are created with this style: `new MyDto().field1(value1).field2(value2)`

  An alternative would be to use the `native` Java `HttpClient` (Java 11+) and Jackson serialisation. We could then reuse the existing DTO classes. We would then have to refactor existing data management API modules to separate DTOs from services into separate packages.

## Decisions

- **Reuse existing DTOs or generate new DTOs?** For quality purposes, my recommendation would be to avoid reusing DTO classes and use generated ones. This ensures that the client behaves exactly and only as specified in the OpenAPI definition, so that the Java client does not have any difference to any other client generated for another language.
- **Commit generated client code, or regenerate on build?** My recommendation would be to regenerate the client on build. This keeps the repo lean, ensures the code is always up to date and does not get manually modified. The time impact is very modest, and should be hardly noticeable in practice thanks to gradle build parallelism and caching.
- **Choice of client library**: My recommendation would be to use the native `HttpClient` rather than `OkHttpClient` to maximise portability and reduce client code size (`OkHttpClient` pulls in Kotlin). Clients who would want the additional advanced features of `OkHttpClient` would anyway be sophisticated enough that having to regenerate their own client from the OpenAPI definitions would hardly be an issue.