### PR TITLE
Azure storage: Ensure resource name is unique to avoid key collisions

### DIFF
--- a/extensions/azure/blobstorage/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageProvisioner.java
+++ b/extensions/azure/blobstorage/blob-provision/src/main/java/org/eclipse/dataspaceconnector/provision/azure/blob/ObjectStorageProvisioner.java
@@ -72,13 +72,15 @@ public class ObjectStorageProvisioner implements Provisioner<ObjectStorageResour
                 })
                 .thenCompose(empty -> createContainerSasToken(containerName, accountName, expiryTime))
                 .thenApply(writeOnlySas -> {
+                    // Ensure resource name is unique to avoid key collisions in local and remote vaults
+                    String resourceName = resourceDefinition.getId() + "-container";
                     var resource = ObjectContainerProvisionedResource.Builder.newInstance()
                             .id(containerName)
                             .accountName(accountName)
                             .containerName(containerName)
                             .resourceDefinitionId(resourceDefinition.getId())
                             .transferProcessId(resourceDefinition.getTransferProcessId())
-                            .resourceName("resource")
+                            .resourceName(resourceName)
                             .hasToken(true)
                             .build();
 


### PR DESCRIPTION
## What this PR changes/adds

When generating an Azure Storage Access Signature for the provider to write data into the consumer's destination blob storage, name the resource with a unique ID (e.g. `eead021e-3a76-44d4-81ec-1d79f2031dcd-container`) rather than with the fixed string `resource`.

## Why it does that

Enable concurrent transfers not to overwrite one another's key in the vault.

## Further notes

## Linked Issue(s)

Relates to #250 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
