### PR TITLE
CI: composite action to setup Java and Gradle

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,0 +1,14 @@
+name: "Setup Gradle"
+description: "Setup Gradle"
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-java@v2
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Setup Gradle cache
+      uses: gradle/gradle-build-action@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,6 +26,7 @@ jobs:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
+      - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-build
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,8 +26,7 @@ jobs:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - uses: ./.github/actions/setup-build
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
@@ -39,12 +38,6 @@ jobs:
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-      - uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'gradle'
 
       # Compiles production Java source (without tests)
       - name: Build

--- a/.github/workflows/generate_openapi_spec.yaml
+++ b/.github/workflows/generate_openapi_spec.yaml
@@ -16,10 +16,7 @@ jobs:
   GenerateOAS:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: '17'
+      - uses: ./.github/actions/setup-build
 
       - name: Generate YAML spec
         env:

--- a/.github/workflows/generate_openapi_spec.yaml
+++ b/.github/workflows/generate_openapi_spec.yaml
@@ -16,6 +16,7 @@ jobs:
   GenerateOAS:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-build
 
       - name: Generate YAML spec

--- a/.github/workflows/performancetests.yaml
+++ b/.github/workflows/performancetests.yaml
@@ -19,6 +19,7 @@ jobs:
       SUCCESS_PERCENTAGE: 100.0
 
     steps:
+      - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-build
 
       - name: Performance Tests

--- a/.github/workflows/performancetests.yaml
+++ b/.github/workflows/performancetests.yaml
@@ -19,13 +19,7 @@ jobs:
       SUCCESS_PERCENTAGE: 100.0
 
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-build
 
       - name: Performance Tests
         run: ./gradlew -p system-tests/tests test -DincludeTags="PerformanceTest"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,11 +21,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v1
-        with:
-          java-version: '17'
+      - uses: ./.github/actions/setup-build
 
       - run: ./gradlew clean -x test publish
         env:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,6 +21,7 @@ jobs:
       packages: write
 
     steps:
+      - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-build
 
       - run: ./gradlew clean -x test publish

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -36,6 +36,7 @@ jobs:
   Dependency-analysis:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-build
 
       - name: Dependency rules report # possible severity values: <'fail'|'warn'|'ignore'>
@@ -49,6 +50,7 @@ jobs:
     env:
       JACOCO: true
     steps:
+      - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-build
 
       - name: Run unit tests
@@ -59,6 +61,7 @@ jobs:
   Sanity-Check:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-build
 
       - name: Check basic launcher
@@ -140,6 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Helm chart in minikube
     steps:
+      - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-build
 
       - name: Install and start minikube
@@ -177,6 +181,7 @@ jobs:
           AZURITE_ACCOUNTS: account1:key1;account2:key2
 
     steps:
+      - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-build
 
       - name: Azure Storage Tests
@@ -208,6 +213,7 @@ jobs:
       COSMOS_URL: ${{ secrets.COSMOS_URL }}
 
     steps:
+      - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-build
 
       - name: Azure CosmosDB Tests
@@ -232,6 +238,7 @@ jobs:
           MINIO_ROOT_PASSWORD: password
 
     steps:
+      - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-build
 
       - name: AWS Tests
@@ -246,6 +253,7 @@ jobs:
       - name: reset permissions to permit checkout (because the omejdn volumes)
         run: sudo chown -R $USER:$USER ${{ github.workspace }}
 
+      - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-build
 
       - run: docker run -d --rm -p 4567:4567 -v ${{ github.workspace }}/extensions/iam/daps/src/test/resources/config:/opt/config -v ${{ github.workspace }}/extensions/iam/daps/src/test/resources/keys:/opt/keys ghcr.io/fraunhofer-aisec/omejdn-server:1.3.1
@@ -283,6 +291,7 @@ jobs:
   End-To-End-Tests:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-build
 
       - name: End to End Integration Tests
@@ -302,6 +311,7 @@ jobs:
       JACOCO: true
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-build
 
       - name: Component Tests
@@ -312,6 +322,7 @@ jobs:
   OpenTelemetry-Integration-Tests:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-build
 
       - name: Download opentelemetry javaagent

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -36,12 +36,7 @@ jobs:
   Dependency-analysis:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-build
 
       - name: Dependency rules report # possible severity values: <'fail'|'warn'|'ignore'>
         run: ./gradlew buildHealth applyDependencyRules -Pdependency.analysis=warn -Pdependency.analysis.clear.artifacts=false
@@ -54,13 +49,7 @@ jobs:
     env:
       JACOCO: true
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-build
 
       - name: Run unit tests
         uses: ./.github/actions/run-tests
@@ -70,13 +59,7 @@ jobs:
   Sanity-Check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-build
 
       - name: Check basic launcher
         run: |
@@ -157,13 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Helm chart in minikube
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          # Do not use cache, as it would cause the test not to run on cache hit
+      - uses: ./.github/actions/setup-build
 
       - name: Install and start minikube
         run: |
@@ -200,13 +177,7 @@ jobs:
           AZURITE_ACCOUNTS: account1:key1;account2:key2
 
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-build
 
       - name: Azure Storage Tests
         uses: ./.github/actions/run-tests
@@ -237,13 +208,7 @@ jobs:
       COSMOS_URL: ${{ secrets.COSMOS_URL }}
 
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-build
 
       - name: Azure CosmosDB Tests
         uses: ./.github/actions/run-tests
@@ -267,13 +232,7 @@ jobs:
           MINIO_ROOT_PASSWORD: password
 
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-build
 
       - name: AWS Tests
         uses: ./.github/actions/run-tests
@@ -287,15 +246,9 @@ jobs:
       - name: reset permissions to permit checkout (because the omejdn volumes)
         run: sudo chown -R $USER:$USER ${{ github.workspace }}
 
-      - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup-build
 
       - run: docker run -d --rm -p 4567:4567 -v ${{ github.workspace }}/extensions/iam/daps/src/test/resources/config:/opt/config -v ${{ github.workspace }}/extensions/iam/daps/src/test/resources/keys:/opt/keys ghcr.io/fraunhofer-aisec/omejdn-server:1.3.1
-
-      - uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
 
       - name: Daps Integration Tests
         uses: ./.github/actions/run-tests
@@ -330,13 +283,7 @@ jobs:
   End-To-End-Tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-build
 
       - name: End to End Integration Tests
         uses: ./.github/actions/run-tests
@@ -355,13 +302,7 @@ jobs:
       JACOCO: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-build
 
       - name: Component Tests
         uses: ./.github/actions/run-tests
@@ -371,12 +312,7 @@ jobs:
   OpenTelemetry-Integration-Tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-build
 
       - name: Download opentelemetry javaagent
         run: wget -q https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.12.0/opentelemetry-javaagent.jar

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -169,10 +169,7 @@ jobs:
       POSTGRES_PWD: ${{ secrets.POSTGRES_PASSWORD }}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: '17'
+      - uses: ./.github/actions/setup-build
 
       - name: Postgres Tests   #just an example!
         uses: ./.github/actions/run-tests


### PR DESCRIPTION
## What this PR changes/adds

- Use a composite action to setup Java and Gradle.
- Use gradle-build-action instead of java-setup with cache: 'gradle'.

## Why it does that

Creating a composite action to setup gradle would avoids repetition and ensures a shared setup.

Using gradle-build-actions has [benefits](https://github.com/gradle/gradle-build-action#why-use-the-gradle-build-action).
More sophisticated and more efficient caching of Gradle User Home between invocations, compared to setup-java and most custom configurations using actions/cache. [More details below](https://github.com/gradle/gradle-build-action#caching).

## Further notes

Deleted an incorrect comment "Do not use cache, as it would cause the test not to run on cache hit"
 
## Linked Issue(s)

#224

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
