### PR TITLE
Feature/1297/264 TP DTO timestamps

### DIFF
--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -52,6 +52,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.command.TransferProcessCommand;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -114,6 +115,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
     private DataAddressResolver addressResolver;
     private PolicyArchive policyArchive;
     private SendRetryManager<TransferProcess> sendRetryManager;
+    protected Clock clock = Clock.systemUTC();
 
     private TransferProcessManagerImpl() {
     }
@@ -190,8 +192,13 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
             return StatusResult.success(processId);
         }
         var id = randomUUID().toString();
-        var process = TransferProcess.Builder.newInstance().id(id).dataRequest(dataRequest).type(type)
-                .traceContext(telemetry.getCurrentTraceContext()).build();
+        var process = TransferProcess.Builder.newInstance()
+                .id(id)
+                .dataRequest(dataRequest)
+                .type(type)
+                .createdTimestamp(clock.millis())
+                .traceContext(telemetry.getCurrentTraceContext())
+                .build();
         if (process.getState() == TransferProcessStates.UNSAVED.code()) {
             process.transitionInitial();
         }

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -57,12 +57,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static java.time.ZoneOffset.UTC;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
@@ -155,6 +158,21 @@ class TransferProcessManagerImplTest {
         manager.stop();
 
         verify(transferProcessStore, times(1)).create(isA(TransferProcess.class));
+        verify(transferProcessStore, times(2)).processIdForTransferId(anyString());
+    }
+
+    @Test
+    void verifyCreatedTimestamp() {
+        when(transferProcessStore.processIdForTransferId("1")).thenReturn(null, "2");
+        DataRequest dataRequest = DataRequest.Builder.newInstance().id("1").destinationType("test").build();
+
+        var currentTime = 1343411;
+        manager.clock = Clock.fixed(Instant.ofEpochMilli(currentTime), UTC);
+        manager.start();
+        manager.initiateProviderRequest(dataRequest);
+        manager.stop();
+
+        verify(transferProcessStore, times(1)).create(argThat(p -> p.getCreatedTimestamp() == currentTime));
         verify(transferProcessStore, times(2)).processIdForTransferId(anyString());
     }
 

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -173,7 +173,6 @@ class TransferProcessManagerImplTest {
         manager.stop();
 
         verify(transferProcessStore, times(1)).create(argThat(p -> p.getCreatedTimestamp() == currentTime));
-        verify(transferProcessStore, times(2)).processIdForTransferId(anyString());
     }
 
     @Test

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferProcessDto.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/model/TransferProcessDto.java
@@ -23,6 +23,8 @@ public class TransferProcessDto {
     private String id;
     private String type;
     private String state;
+    private Long stateTimestamp;
+    private Long createdTimestamp;
     private String errorDetail;
     private DataRequestDto dataRequest;
     private DataAddressInformationDto dataDestination;
@@ -40,6 +42,14 @@ public class TransferProcessDto {
 
     public String getState() {
         return state;
+    }
+
+    public Long getStateTimestamp() {
+        return stateTimestamp;
+    }
+
+    public Long getCreatedTimestamp() {
+        return createdTimestamp;
     }
 
     public String getErrorDetail() {
@@ -79,6 +89,16 @@ public class TransferProcessDto {
 
         public Builder state(String state) {
             transferProcessDto.state = state;
+            return this;
+        }
+
+        public Builder stateTimestamp(Long stateTimestamp) {
+            transferProcessDto.stateTimestamp = stateTimestamp;
+            return this;
+        }
+
+        public Builder createdTimestamp(Long createdTimestamp) {
+            transferProcessDto.createdTimestamp = createdTimestamp;
             return this;
         }
 

--- a/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
+++ b/extensions/api/data-management/transferprocess/src/main/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
@@ -45,6 +45,8 @@ public class TransferProcessToTransferProcessDtoTransformer implements DtoTransf
                 .id(object.getId())
                 .type(object.getType().name())
                 .state(getState(object.getState(), context))
+                .stateTimestamp(object.getStateTimestamp())
+                .createdTimestamp(object.getCreatedTimestamp())
                 .errorDetail(object.getErrorDetail())
                 .dataRequest(context.transform(object.getDataRequest(), DataRequestDto.class))
                 .dataDestination(

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformerTest.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessToTransferProcessDtoTransformerTest.java
@@ -73,12 +73,15 @@ class TransferProcessToTransferProcessDtoTransformerTest {
         data.entity = TransferProcess.Builder.newInstance()
                 .id(data.id)
                 .type(data.type)
+                .stateTimestamp(data.stateTimestamp)
                 .dataRequest(data.dataRequest);
         data.dto
                 .dataDestination(
                         DataAddressInformationDto.Builder.newInstance()
                                 .properties(Map.of("type", data.dataDestinationType))
                                 .build())
+                .stateTimestamp(data.stateTimestamp)
+                .createdTimestamp(0L)
                 .errorDetail(null);
 
         assertThatEntityTransformsToDto();

--- a/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessTransformerTestData.java
+++ b/extensions/api/data-management/transferprocess/src/test/java/org/eclipse/dataspaceconnector/api/datamanagement/transferprocess/transform/TransferProcessTransformerTestData.java
@@ -39,6 +39,8 @@ public class TransferProcessTransformerTestData {
     String id = faker.lorem().word();
     TransferProcess.Type type = faker.options().option(TransferProcess.Type.class);
     TransferProcessStates state = faker.options().option(TransferProcessStates.class);
+    long stateTimestamp = faker.random().nextLong();
+    long createdTimestamp = faker.random().nextLong();
     String errorDetail = faker.lorem().word();
 
     Map<String, String> dataDestinationProperties = Map.of(faker.lorem().word(), faker.lorem().word());
@@ -53,6 +55,8 @@ public class TransferProcessTransformerTestData {
             .id(id)
             .type(type)
             .state(state.code())
+            .stateTimestamp(stateTimestamp)
+            .createdTimestamp(createdTimestamp)
             .errorDetail(errorDetail)
             .dataRequest(dataRequest);
 
@@ -60,6 +64,8 @@ public class TransferProcessTransformerTestData {
             .id(id)
             .type(type.name())
             .state(state.name())
+            .stateTimestamp(stateTimestamp)
+            .createdTimestamp(createdTimestamp)
             .errorDetail(errorDetail)
             .dataRequest(dataRequestDto)
             .dataDestination(

--- a/extensions/sql/transfer-process-store-sql/docs/schema.sql
+++ b/extensions/sql/transfer-process-store-sql/docs/schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS edc_transfer_process
     state                    INTEGER           NOT NULL,
     state_count              INTEGER DEFAULT 0 NOT NULL,
     state_time_stamp         BIGINT,
+    created_time_stamp       BIGINT,
     trace_context            VARCHAR,
     error_detail             VARCHAR,
     resource_manifest        VARCHAR,

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/PostgresStatements.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/PostgresStatements.java
@@ -44,8 +44,9 @@ public class PostgresStatements implements TransferProcessStoreStatements {
 
     @Override
     public String getInsertStatement() {
-        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
                 getTableName(), getIdColumn(), getStateColumn(), getStateCountColumn(), getStateTimestampColumn(),
+                getCreatedTimestampColumn(),
                 getTraceContextColumn(), getErrorDetailColumn(), getResourceManifestColumn(),
                 getProvisionedResourcesetColumn(), getContentDataAddressColumn(), getTypeColumn());
     }

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -36,6 +36,7 @@ import org.jetbrains.annotations.Nullable;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -53,6 +54,7 @@ public class SqlTransferProcessStore implements TransferProcessStore {
     private final TransferProcessStoreStatements statements;
     private final String leaseHolderName;
     private final SqlLeaseContextBuilder leaseContext;
+    protected Clock clock = Clock.systemUTC();
 
     public SqlTransferProcessStore(DataSourceRegistry dataSourceRegistry, String datasourceName, TransactionContext transactionContext, ObjectMapper objectMapper, TransferProcessStoreStatements statements, String leaseHolderName) {
 
@@ -217,6 +219,7 @@ public class SqlTransferProcessStore implements TransferProcessStore {
                         process.getState(),
                         process.getStateCount(),
                         process.getStateTimestamp(),
+                        process.getCreatedTimestamp(),
                         toJson(process.getTraceContext()),
                         process.getErrorDetail(),
                         toJson(process.getResourceManifest()),
@@ -250,6 +253,7 @@ public class SqlTransferProcessStore implements TransferProcessStore {
         return TransferProcess.Builder.newInstance()
                 .id(resultSet.getString(statements.getIdColumn()))
                 .type(TransferProcess.Type.valueOf(resultSet.getString(statements.getTypeColumn())))
+                .createdTimestamp(resultSet.getLong(statements.getCreatedTimestampColumn()))
                 .state(resultSet.getInt(statements.getStateColumn()))
                 .stateTimestamp(resultSet.getLong(statements.getStateTimestampColumn()))
                 .stateCount(resultSet.getInt(statements.getStateCountColumn()))

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -36,7 +36,6 @@ import org.jetbrains.annotations.Nullable;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,7 +53,6 @@ public class SqlTransferProcessStore implements TransferProcessStore {
     private final TransferProcessStoreStatements statements;
     private final String leaseHolderName;
     private final SqlLeaseContextBuilder leaseContext;
-    protected Clock clock = Clock.systemUTC();
 
     public SqlTransferProcessStore(DataSourceRegistry dataSourceRegistry, String datasourceName, TransactionContext transactionContext, ObjectMapper objectMapper, TransferProcessStoreStatements statements, String leaseHolderName) {
 

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/TransferProcessStoreStatements.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/TransferProcessStoreStatements.java
@@ -74,9 +74,9 @@ public interface TransferProcessStoreStatements extends LeaseStatements {
         return "type";
     }
 
-        default String getCreatedTimestampColumn() {
-            return "created_time_stamp";
-        }
+    default String getCreatedTimestampColumn() {
+        return "created_time_stamp";
+    }
 
     default String getContentDataAddressColumn() {
         return "content_data_address";

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/TransferProcessStoreStatements.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/TransferProcessStoreStatements.java
@@ -74,6 +74,10 @@ public interface TransferProcessStoreStatements extends LeaseStatements {
         return "type";
     }
 
+        default String getCreatedTimestampColumn() {
+            return "created_time_stamp";
+        }
+
     default String getContentDataAddressColumn() {
         return "content_data_address";
     }

--- a/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/TestFunctions.java
+++ b/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/TestFunctions.java
@@ -59,6 +59,7 @@ class TestFunctions {
         return TransferProcess.Builder.newInstance()
                 .id(processId)
                 .state(state.code())
+                .createdTimestamp(12314)
                 .type(TransferProcess.Type.CONSUMER)
                 .dataRequest(createDataRequest())
                 .contentDataAddress(DataAddress.Builder.newInstance().type("any").build())

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -9,79 +9,108 @@ info:
 servers:
 - url: /
 paths:
-  /identity-hub/query-commits:
+  /federatedcatalog:
     post:
-      tags:
-      - Identity Hub
-      operationId: queryCommits
+      operationId: getCachedCatalog
       requestBody:
         content:
           application/json:
             schema:
-              type: string
+              $ref: '#/components/schemas/FederatedCatalogCacheQuery'
       responses:
         default:
           description: default response
           content:
             application/json:
               schema:
-                type: string
-  /identity-hub/query-objects:
-    post:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractOffer'
+  /instances:
+    get:
       tags:
-      - Identity Hub
-      operationId: queryObjects
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
+      - Dataplane Selector
+      operationId: getAll
       responses:
         default:
           description: default response
           content:
             application/json:
               schema:
-                type: string
-  /identity-hub/collections:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataPlaneInstance'
     post:
       tags:
-      - Identity Hub
-      operationId: write
+      - Dataplane Selector
+      operationId: addEntry
       requestBody:
         content:
           application/json:
             schema:
-              type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: string
-  /identity-hub/collections-commit:
-    post:
-      tags:
-      - Identity Hub
-      operationId: writeCommit
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties:
-                type: string
+              $ref: '#/components/schemas/DataPlaneInstance'
       responses:
         default:
           description: default response
           content:
             application/json: {}
-  /control/catalog:
+  /instances/select:
+    post:
+      tags:
+      - Dataplane Selector
+      operationId: find
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SelectionRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataPlaneInstance'
+  /policies:
     get:
-      operationId: getDescription
+      tags:
+      - Policy
+      operationId: getAllPolicies
       parameters:
-      - name: provider
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
         in: query
         required: false
         style: form
@@ -92,25 +121,49 @@ paths:
         default:
           description: default response
           content:
-            application/json: {}
-      deprecated: true
-  /control/transfer:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Policy'
     post:
-      operationId: addTransfer
+      tags:
+      - Policy
+      operationId: createPolicy
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DataRequest'
+              $ref: '#/components/schemas/Policy'
       responses:
         default:
           description: default response
           content:
             application/json: {}
-      deprecated: true
-  /control/agreement/{id}:
+  /policies/{id}:
     get:
-      operationId: getAgreementById
+      tags:
+      - Policy
+      operationId: getPolicy
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Policy'
+    delete:
+      tags:
+      - Policy
+      operationId: deletePolicy
       parameters:
       - name: id
         in: path
@@ -124,55 +177,46 @@ paths:
           description: default response
           content:
             application/json: {}
-      deprecated: true
-  /control/negotiation/{id}:
+  /check/health:
     get:
-      operationId: getNegotiationById
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+      tags:
+      - Application Observability
+      operationId: checkHealth
       responses:
         default:
           description: default response
           content:
             application/json: {}
-      deprecated: true
-  /control/negotiation/{id}/state:
+  /check/liveness:
     get:
-      operationId: getNegotiationStateById
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+      tags:
+      - Application Observability
+      operationId: getLiveness
       responses:
         default:
           description: default response
           content:
             application/json: {}
-      deprecated: true
-  /control/negotiation:
-    post:
-      operationId: initiateNegotiation
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ContractOfferRequest'
+  /check/readiness:
+    get:
+      tags:
+      - Application Observability
+      operationId: getReadiness
       responses:
         default:
           description: default response
           content:
             application/json: {}
-      deprecated: true
+  /check/startup:
+    get:
+      tags:
+      - Application Observability
+      operationId: getStartup
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
   /contractnegotiations/{id}/cancel:
     post:
       tags:
@@ -340,11 +384,88 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NegotiationId'
-  /instances:
+  /transferprocess/{id}/cancel:
+    post:
+      tags:
+      - Transfer Process
+      operationId: cancelTransferProcess
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /transferprocess/{id}/deprovision:
+    post:
+      tags:
+      - Transfer Process
+      operationId: deprovisionTransferProcess
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /transferprocess:
     get:
       tags:
-      - Dataplane Selector
-      operationId: getAll
+      - Transfer Process
+      operationId: getAllTransferProcesses
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
       responses:
         default:
           description: default response
@@ -353,38 +474,237 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DataPlaneInstance'
+                  $ref: '#/components/schemas/TransferProcessDto'
     post:
       tags:
-      - Dataplane Selector
-      operationId: addEntry
+      - Transfer Process
+      operationId: initiateTransfer
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DataPlaneInstance'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /instances/select:
-    post:
-      tags:
-      - Dataplane Selector
-      operationId: find
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SelectionRequest'
+              $ref: '#/components/schemas/TransferRequestDto'
       responses:
         default:
           description: default response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DataPlaneInstance'
+                $ref: '#/components/schemas/TransferId'
+  /transferprocess/{id}:
+    get:
+      tags:
+      - Transfer Process
+      operationId: getTransferProcess
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransferProcessDto'
+  /transferprocess/{id}/state:
+    get:
+      tags:
+      - Transfer Process
+      operationId: getTransferProcessState
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransferState'
+  /contractdefinitions:
+    get:
+      tags:
+      - Contract Definition
+      operationId: getAllContractDefinitions
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractDefinitionDto'
+    post:
+      tags:
+      - Contract Definition
+      operationId: createContractDefinition
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/ContractDefinitionDto'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /contractdefinitions/{id}:
+    get:
+      tags:
+      - Contract Definition
+      operationId: getContractDefinition
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractDefinitionDto'
+    delete:
+      tags:
+      - Contract Definition
+      operationId: deleteContractDefinition
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /identity-hub/query-commits:
+    post:
+      tags:
+      - Identity Hub
+      operationId: queryCommits
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/query-objects:
+    post:
+      tags:
+      - Identity Hub
+      operationId: queryObjects
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/collections:
+    post:
+      tags:
+      - Identity Hub
+      operationId: write
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: string
+  /identity-hub/collections-commit:
+    post:
+      tags:
+      - Identity Hub
+      operationId: writeCommit
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
   /assets:
     get:
       tags:
@@ -566,442 +886,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ContractAgreementDto'
-  /check/health:
-    get:
-      tags:
-      - Application Observability
-      operationId: checkHealth
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /check/liveness:
-    get:
-      tags:
-      - Application Observability
-      operationId: getLiveness
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /check/readiness:
-    get:
-      tags:
-      - Application Observability
-      operationId: getReadiness
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /check/startup:
-    get:
-      tags:
-      - Application Observability
-      operationId: getStartup
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /transferprocess/{id}/cancel:
-    post:
-      tags:
-      - Transfer Process
-      operationId: cancelTransferProcess
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /transferprocess/{id}/deprovision:
-    post:
-      tags:
-      - Transfer Process
-      operationId: deprovisionTransferProcess
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /transferprocess:
-    get:
-      tags:
-      - Transfer Process
-      operationId: getAllTransferProcesses
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/TransferProcessDto'
-    post:
-      tags:
-      - Transfer Process
-      operationId: initiateTransfer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TransferRequestDto'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TransferId'
-  /transferprocess/{id}:
-    get:
-      tags:
-      - Transfer Process
-      operationId: getTransferProcess
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TransferProcessDto'
-  /transferprocess/{id}/state:
-    get:
-      tags:
-      - Transfer Process
-      operationId: getTransferProcessState
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TransferState'
-  /policies:
-    get:
-      tags:
-      - Policy
-      operationId: getAllPolicies
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Policy'
-    post:
-      tags:
-      - Policy
-      operationId: createPolicy
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Policy'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /policies/{id}:
-    get:
-      tags:
-      - Policy
-      operationId: getPolicy
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Policy'
-    delete:
-      tags:
-      - Policy
-      operationId: deletePolicy
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /catalog:
-    get:
-      tags:
-      - Catalog
-      operationId: getCatalog
-      parameters:
-      - name: providerUrl
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: Gets contract offers (=catalog) of a single connector
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Catalog'
-  /federatedcatalog:
-    post:
-      operationId: getCachedCatalog
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FederatedCatalogCacheQuery'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractOffer'
-  /contractdefinitions:
-    get:
-      tags:
-      - Contract Definition
-      operationId: getAllContractDefinitions
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractDefinitionDto'
-    post:
-      tags:
-      - Contract Definition
-      operationId: createContractDefinition
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/ContractDefinitionDto'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /contractdefinitions/{id}:
-    get:
-      tags:
-      - Contract Definition
-      operationId: getContractDefinition
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ContractDefinitionDto'
-    delete:
-      tags:
-      - Contract Definition
-      operationId: deleteContractDefinition
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
   /callback/{processId}/deprovision:
     post:
       tags:
@@ -1048,6 +932,122 @@ paths:
           description: default response
           content:
             application/json: {}
+  /catalog:
+    get:
+      tags:
+      - Catalog
+      operationId: getCatalog
+      parameters:
+      - name: providerUrl
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: Gets contract offers (=catalog) of a single connector
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Catalog'
+  /control/catalog:
+    get:
+      operationId: getDescription
+      parameters:
+      - name: provider
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      deprecated: true
+  /control/transfer:
+    post:
+      operationId: addTransfer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      deprecated: true
+  /control/agreement/{id}:
+    get:
+      operationId: getAgreementById
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      deprecated: true
+  /control/negotiation/{id}:
+    get:
+      operationId: getNegotiationById
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      deprecated: true
+  /control/negotiation/{id}/state:
+    get:
+      operationId: getNegotiationStateById
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      deprecated: true
+  /control/negotiation:
+    post:
+      operationId: initiateNegotiation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ContractOfferRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      deprecated: true
 components:
   schemas:
     Action:
@@ -1259,21 +1259,21 @@ components:
     DataPlaneInstance:
       type: object
       properties:
-        id:
-          type: string
-        url:
-          type: string
-          format: url
-        turnCount:
-          type: integer
-          format: int32
         lastActive:
           type: integer
           format: int64
+        turnCount:
+          type: integer
+          format: int32
+        url:
+          type: string
+          format: url
         properties:
           type: object
           additionalProperties:
             type: object
+        id:
+          type: string
     DataRequest:
       type: object
       properties:
@@ -1493,6 +1493,12 @@ components:
           type: string
         state:
           type: string
+        stateTimestamp:
+          type: integer
+          format: int64
+        createdTimestamp:
+          type: integer
+          format: int64
         errorDetail:
           type: string
         dataRequest:

--- a/resources/openapi/yaml/selector-api.yaml
+++ b/resources/openapi/yaml/selector-api.yaml
@@ -50,21 +50,21 @@ components:
     DataPlaneInstance:
       type: object
       properties:
-        id:
-          type: string
-        url:
-          type: string
-          format: url
-        turnCount:
-          type: integer
-          format: int32
         lastActive:
           type: integer
           format: int64
+        turnCount:
+          type: integer
+          format: int32
+        url:
+          type: string
+          format: url
         properties:
           type: object
           additionalProperties:
             type: object
+        id:
+          type: string
     DataAddress:
       type: object
       properties:

--- a/resources/openapi/yaml/transferprocess.yaml
+++ b/resources/openapi/yaml/transferprocess.yaml
@@ -151,6 +151,12 @@ components:
           type: string
         state:
           type: string
+        stateTimestamp:
+          type: integer
+          format: int64
+        createdTimestamp:
+          type: integer
+          format: int64
         errorDetail:
           type: string
         dataRequest:

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
@@ -100,6 +100,7 @@ public class TransferProcess implements TraceCarrier {
 
     private String id;
     private Type type = Type.CONSUMER;
+    private long createdTimestamp;
     private int state;
     private int stateCount = UNSAVED.code();
     private long stateTimestamp;
@@ -116,6 +117,10 @@ public class TransferProcess implements TraceCarrier {
 
     public String getId() {
         return id;
+    }
+
+    public long getCreatedTimestamp() {
+        return createdTimestamp;
     }
 
     public Type getType() {
@@ -340,6 +345,7 @@ public class TransferProcess implements TraceCarrier {
                 .contentDataAddress(contentDataAddress)
                 .traceContext(traceContext)
                 .type(type)
+                .createdTimestamp(createdTimestamp)
                 .errorDetail(errorDetail)
                 .build();
     }
@@ -416,6 +422,11 @@ public class TransferProcess implements TraceCarrier {
 
         public Builder type(Type type) {
             process.type = type;
+            return this;
+        }
+
+        public Builder createdTimestamp(long value) {
+            process.createdTimestamp = value;
             return this;
         }
 

--- a/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcessTest.java
+++ b/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcessTest.java
@@ -58,6 +58,7 @@ class TransferProcessTest {
                 .newInstance()
                 .id(UUID.randomUUID().toString())
                 .type(TransferProcess.Type.PROVIDER)
+                .createdTimestamp(3)
                 .state(TransferProcessStates.COMPLETED.code())
                 .contentDataAddress(DataAddress.Builder.newInstance().type("test").build())
                 .stateCount(1)
@@ -68,6 +69,7 @@ class TransferProcessTest {
 
         assertEquals(process.getState(), copy.getState());
         assertEquals(process.getType(), copy.getType());
+        assertEquals(process.getCreatedTimestamp(), copy.getCreatedTimestamp());
         assertEquals(process.getStateCount(), copy.getStateCount());
         assertEquals(process.getStateTimestamp(), copy.getStateTimestamp());
         assertNotNull(process.getContentDataAddress());


### PR DESCRIPTION
## What this PR changes/adds

Add timestamps when querying TransferProcesses in Data management API.

## Why it does that

Useful for web front-ends, to allow to sort transfers by dates.

## Further notes

## Linked Issue(s)

#264

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
