### PR TITLE
Feature/1364/284 clock

### DIFF
--- a/core/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
+++ b/core/base/src/main/java/org/eclipse/dataspaceconnector/core/CoreServicesExtension.java
@@ -53,6 +53,7 @@ import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 
 import java.security.PrivateKey;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ExecutorService;
@@ -65,6 +66,7 @@ import static java.util.Optional.ofNullable;
         HealthCheckService.class,
         Monitor.class,
         TypeManager.class,
+        Clock.class,
         Telemetry.class
 })
 public class CoreServicesExtension implements ServiceExtension {

--- a/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/DefaultServiceExtensionContext.java
+++ b/core/boot/src/main/java/org/eclipse/dataspaceconnector/boot/system/DefaultServiceExtensionContext.java
@@ -24,6 +24,7 @@ import org.eclipse.dataspaceconnector.spi.system.configuration.ConfigFactory;
 import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 
+import java.time.Clock;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,26 +48,12 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
         registerService(TypeManager.class, typeManager);
         registerService(Monitor.class, monitor);
         registerService(Telemetry.class, telemetry);
+        registerService(Clock.class, Clock.systemUTC());
     }
 
     @Override
     public String getConnectorId() {
         return connectorId;
-    }
-
-    @Override
-    public Monitor getMonitor() {
-        return getService(Monitor.class);
-    }
-
-    @Override
-    public Telemetry getTelemetry() {
-        return getService(Telemetry.class);
-    }
-
-    @Override
-    public TypeManager getTypeManager() {
-        return getService(TypeManager.class);
     }
 
     @Override

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/ContractServiceExtension.java
@@ -52,6 +52,7 @@ import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiation;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.command.ContractNegotiationCommand;
 
@@ -65,7 +66,6 @@ import java.time.Clock;
 public class ContractServiceExtension implements ServiceExtension {
 
     private static final long DEFAULT_ITERATION_WAIT = 5000; // millis
-    private Monitor monitor;
     private ConsumerContractNegotiationManagerImpl consumerNegotiationManager;
     private ProviderContractNegotiationManagerImpl providerNegotiationManager;
 
@@ -100,6 +100,12 @@ public class ContractServiceExtension implements ServiceExtension {
     private PolicyStore policyStore;
 
     @Inject
+    private Monitor monitor;
+
+    @Inject
+    private Telemetry telemetry;
+
+    @Inject
     private Clock clock;
 
     @Override
@@ -109,8 +115,6 @@ public class ContractServiceExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        monitor = context.getMonitor();
-
         registerTypes(context);
         registerServices(context);
     }
@@ -147,8 +151,6 @@ public class ContractServiceExtension implements ServiceExtension {
         CommandQueue<ContractNegotiationCommand> commandQueue = new BoundedCommandQueue<>(10);
         CommandRunner<ContractNegotiationCommand> commandRunner = new CommandRunner<>(commandHandlerRegistry, monitor);
 
-        var clock = context.getClock();
-        var telemetry = context.getTelemetry();
         var observable = new ContractNegotiationObservableImpl();
         context.registerService(ContractNegotiationObservable.class, observable);
 

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationManager.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/AbstractContractNegotiationManager.java
@@ -28,6 +28,7 @@ import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
 import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.command.ContractNegotiationCommand;
 
+import java.time.Clock;
 import java.util.Objects;
 
 public abstract class AbstractContractNegotiationManager {
@@ -40,6 +41,7 @@ public abstract class AbstractContractNegotiationManager {
     protected CommandRunner<ContractNegotiationCommand> commandRunner;
     protected CommandProcessor<ContractNegotiationCommand> commandProcessor;
     protected Monitor monitor;
+    protected Clock clock;
     protected Telemetry telemetry;
     protected ExecutorInstrumentation executorInstrumentation;
     protected int batchSize = 5;
@@ -52,6 +54,7 @@ public abstract class AbstractContractNegotiationManager {
 
         protected Builder(T manager) {
             this.manager = manager;
+            this.manager.clock = Clock.systemUTC(); // default implementation
             this.manager.telemetry = new Telemetry(); // default noop implementation
             this.manager.executorInstrumentation = ExecutorInstrumentation.noop(); // default noop implementation
         }
@@ -91,6 +94,11 @@ public abstract class AbstractContractNegotiationManager {
             return this;
         }
 
+        public Builder<T> clock(Clock clock) {
+            manager.clock = clock;
+            return this;
+        }
+
         public Builder<T> telemetry(Telemetry telemetry) {
             manager.telemetry = telemetry;
             return this;
@@ -123,6 +131,7 @@ public abstract class AbstractContractNegotiationManager {
             Objects.requireNonNull(manager.commandQueue, "commandQueue");
             Objects.requireNonNull(manager.commandRunner, "commandRunner");
             Objects.requireNonNull(manager.observable, "observable");
+            Objects.requireNonNull(manager.clock, "clock");
             Objects.requireNonNull(manager.telemetry, "telemetry");
             Objects.requireNonNull(manager.executorInstrumentation, "executorInstrumentation");
             Objects.requireNonNull(manager.negotiationStore, "store");

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -37,7 +37,6 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.comm
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.UUID;
@@ -395,9 +394,9 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
         var policy = lastOffer.getPolicy();
         var agreement = ContractAgreement.Builder.newInstance()
                 .id(ContractId.createContractId(definitionId))
-                .contractStartDate(Instant.now().getEpochSecond())
-                .contractEndDate(Instant.now().plus(365, ChronoUnit.DAYS).getEpochSecond()) // TODO Make configurable (issue #722)
-                .contractSigningDate(Instant.now().getEpochSecond())
+                .contractStartDate(clock.instant().getEpochSecond())
+                .contractEndDate(clock.instant().plus(365, ChronoUnit.DAYS).getEpochSecond()) // TODO Make configurable (issue #722)
+                .contractSigningDate(clock.instant().getEpochSecond())
                 .providerAgentId(String.valueOf(lastOffer.getProvider()))
                 .consumerAgentId(String.valueOf(lastOffer.getConsumer()))
                 .policyId(policy.getUid())

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -37,7 +37,6 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.comm
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 import java.util.function.BiConsumer;
@@ -386,9 +385,9 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
             //TODO move to own service
             agreement = ContractAgreement.Builder.newInstance()
                     .id(ContractId.createContractId(definitionId))
-                    .contractStartDate(Instant.now().getEpochSecond())
-                    .contractEndDate(Instant.now().plus(365, ChronoUnit.DAYS).getEpochSecond()) // TODO Make configurable (issue #722)
-                    .contractSigningDate(Instant.now().getEpochSecond())
+                    .contractStartDate(clock.instant().getEpochSecond())
+                    .contractEndDate(clock.instant().plus(365, ChronoUnit.DAYS).getEpochSecond()) // TODO Make configurable (issue #722)
+                    .contractSigningDate(clock.instant().getEpochSecond())
                     .providerAgentId(String.valueOf(lastOffer.getProvider()))
                     .consumerAgentId(String.valueOf(lastOffer.getConsumer()))
                     .policyId(policy.getUid())

--- a/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImpl.java
+++ b/core/contract/src/main/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImpl.java
@@ -31,7 +31,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractDe
 import org.eclipse.dataspaceconnector.spi.types.domain.contract.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 
-import java.time.Instant;
+import java.time.Clock;
 import java.util.ArrayList;
 
 import static java.lang.String.format;
@@ -47,12 +47,14 @@ public class ContractValidationServiceImpl implements ContractValidationService 
     private final ContractDefinitionService contractDefinitionService;
     private final AssetIndex assetIndex;
     private final PolicyStore policyStore;
+    private final Clock clock;
 
-    public ContractValidationServiceImpl(ParticipantAgentService agentService, ContractDefinitionService contractDefinitionService, AssetIndex assetIndex, PolicyStore policyStore) {
+    public ContractValidationServiceImpl(ParticipantAgentService agentService, ContractDefinitionService contractDefinitionService, AssetIndex assetIndex, PolicyStore policyStore, Clock clock) {
         this.agentService = agentService;
         this.contractDefinitionService = contractDefinitionService;
         this.assetIndex = assetIndex;
         this.policyStore = policyStore;
+        this.clock = clock;
     }
 
     @Override
@@ -143,11 +145,11 @@ public class ContractValidationServiceImpl implements ContractValidationService 
     }
 
     private boolean isExpired(ContractAgreement contractAgreement) {
-        return contractAgreement.getContractEndDate() < Instant.now().getEpochSecond();
+        return contractAgreement.getContractEndDate() * 1000L < clock.millis();
     }
 
     private boolean isStarted(ContractAgreement contractAgreement) {
-        return contractAgreement.getContractStartDate() <= Instant.now().getEpochSecond();
+        return contractAgreement.getContractStartDate() * 1000L <= clock.millis();
     }
 
     private boolean isMandatoryAttributeMissing(ContractOffer offer) {

--- a/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/contract/src/test/java/org/eclipse/dataspaceconnector/contract/validation/ContractValidationServiceImplTest.java
@@ -16,6 +16,7 @@
 
 package org.eclipse.dataspaceconnector.contract.validation;
 
+import com.github.javafaker.Faker;
 import org.eclipse.dataspaceconnector.policy.model.Policy;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgent;
 import org.eclipse.dataspaceconnector.spi.agent.ParticipantAgentService;
@@ -33,13 +34,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+import static java.time.Instant.EPOCH;
 import static java.time.Instant.MAX;
 import static java.time.Instant.MIN;
+import static java.time.ZoneOffset.UTC;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -51,15 +56,19 @@ import static org.mockito.Mockito.when;
 
 class ContractValidationServiceImplTest {
 
+    private static final Faker FAKER = new Faker();
+    private final Instant now = Instant.now();
+
     private final ParticipantAgentService agentService = mock(ParticipantAgentService.class);
     private final ContractDefinitionService definitionService = mock(ContractDefinitionService.class);
     private final AssetIndex assetIndex = mock(AssetIndex.class);
     private final PolicyStore policyStore = mock(PolicyStore.class);
+    private final Clock clock = Clock.fixed(now, UTC);
     private ContractValidationServiceImpl validationService;
 
     @BeforeEach
     void setUp() {
-        validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore);
+        validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, clock);
     }
 
     @Test
@@ -119,9 +128,9 @@ class ContractValidationServiceImplTest {
                 .consumerAgentId("consumer")
                 .policyId("policy")
                 .assetId(UUID.randomUUID().toString())
-                .contractStartDate(Instant.now().getEpochSecond())
-                .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
-                .contractSigningDate(Instant.now().getEpochSecond())
+                .contractStartDate(now.getEpochSecond())
+                .contractEndDate(now.plus(1, ChronoUnit.DAYS).getEpochSecond())
+                .contractSigningDate(now.getEpochSecond())
                 .id("1:2").build();
 
         assertThat(validationService.validate(claimToken, agreement)).isTrue();
@@ -131,8 +140,9 @@ class ContractValidationServiceImplTest {
 
     @Test
     void verifyContractAgreementExpired() {
+        var past = FAKER.date().between(Date.from(EPOCH), Date.from(now)).toInstant().getEpochSecond();
         var isValid =
-                validateAgreementDate(MIN.getEpochSecond(), MIN.getEpochSecond(), Instant.now().getEpochSecond() - 1);
+                validateAgreementDate(MIN.getEpochSecond(), MIN.getEpochSecond(), past);
 
         assertThat(isValid).isFalse();
     }

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/CoreTransferExtension.java
@@ -59,6 +59,8 @@ import org.eclipse.dataspaceconnector.transfer.core.transfer.StatusCheckerRegist
 import org.eclipse.dataspaceconnector.transfer.core.transfer.TransferProcessManagerImpl;
 import org.eclipse.dataspaceconnector.transfer.core.transfer.TransferProcessSendRetryManager;
 
+import java.time.Clock;
+
 /**
  * Provides core data transfer services to the system.
  */
@@ -141,7 +143,8 @@ public class CoreTransferExtension implements ServiceExtension {
 
         var retryLimit = context.getSetting(TRANSFER_SEND_RETRY_LIMIT, 7);
         var retryBaseDelay = context.getSetting(TRANSFER_SEND_RETRY_BASE_DELAY_MS, 100L);
-        var sendRetryManager = new TransferProcessSendRetryManager(monitor, () -> new ExponentialWaitStrategy(retryBaseDelay), retryLimit);
+        Clock clock = context.getClock();
+        var sendRetryManager = new TransferProcessSendRetryManager(monitor, () -> new ExponentialWaitStrategy(retryBaseDelay), clock, retryLimit);
 
         processManager = TransferProcessManagerImpl.Builder.newInstance()
                 .waitStrategy(waitStrategy)
@@ -154,6 +157,7 @@ public class CoreTransferExtension implements ServiceExtension {
                 .telemetry(telemetry)
                 .executorInstrumentation(context.getService(ExecutorInstrumentation.class))
                 .vault(vault)
+                .clock(clock)
                 .typeManager(typeManager)
                 .commandQueue(commandQueue)
                 .commandRunner(new CommandRunner<>(registry, monitor))

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -115,7 +115,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
     private DataAddressResolver addressResolver;
     private PolicyArchive policyArchive;
     private SendRetryManager<TransferProcess> sendRetryManager;
-    protected Clock clock = Clock.systemUTC();
+    private Clock clock;
 
     private TransferProcessManagerImpl() {
     }
@@ -709,6 +709,11 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
 
         public Builder executorInstrumentation(ExecutorInstrumentation executorInstrumentation) {
             manager.executorInstrumentation = executorInstrumentation;
+            return this;
+        }
+
+        public Builder clock(Clock clock) {
+            manager.clock = clock;
             return this;
         }
 

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessSendRetryManager.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessSendRetryManager.java
@@ -32,11 +32,12 @@ public class TransferProcessSendRetryManager implements SendRetryManager<Transfe
     private final Monitor monitor;
     private final Supplier<WaitStrategy> delayStrategySupplier;
     private final int retryLimit;
-    protected Clock clock = Clock.systemUTC();
+    private final Clock clock;
 
-    public TransferProcessSendRetryManager(Monitor monitor, Supplier<WaitStrategy> delayStrategySupplier, int retryLimit) {
+    public TransferProcessSendRetryManager(Monitor monitor, Supplier<WaitStrategy> delayStrategySupplier, Clock clock, int retryLimit) {
         this.monitor = monitor;
         this.delayStrategySupplier = delayStrategySupplier;
+        this.clock = clock;
         this.retryLimit = retryLimit;
     }
 

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplIntegrationTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -89,6 +90,7 @@ class TransferProcessManagerImplIntegrationTest {
                 .dispatcherRegistry(mock(RemoteMessageDispatcherRegistry.class))
                 .manifestGenerator(manifestGenerator)
                 .monitor(mock(Monitor.class))
+                .clock(Clock.systemUTC())
                 .commandQueue(mock(CommandQueue.class))
                 .commandRunner(mock(CommandRunner.class))
                 .typeManager(new TypeManager())

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -107,6 +107,8 @@ class TransferProcessManagerImplTest {
     private static final int TRANSFER_MANAGER_BATCHSIZE = 10;
     private static final String PROVISIONED_RESOURCE_ID = "1";
 
+    private final long currentTime = 1343411;
+
     private final ProvisionManager provisionManager = mock(ProvisionManager.class);
     private final RemoteMessageDispatcherRegistry dispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
     private final StatusCheckerRegistry statusCheckerRegistry = mock(StatusCheckerRegistry.class);
@@ -134,6 +136,7 @@ class TransferProcessManagerImplTest {
                 .commandQueue(mock(CommandQueue.class))
                 .commandRunner(mock(CommandRunner.class))
                 .typeManager(new TypeManager())
+                .clock(Clock.fixed(Instant.ofEpochMilli(currentTime), UTC))
                 .statusCheckerRegistry(statusCheckerRegistry)
                 .observable(mock(TransferProcessObservable.class))
                 .transferProcessStore(transferProcessStore)
@@ -166,8 +169,6 @@ class TransferProcessManagerImplTest {
         when(transferProcessStore.processIdForTransferId("1")).thenReturn(null, "2");
         DataRequest dataRequest = DataRequest.Builder.newInstance().id("1").destinationType("test").build();
 
-        var currentTime = 1343411;
-        manager.clock = Clock.fixed(Instant.ofEpochMilli(currentTime), UTC);
         manager.start();
         manager.initiateProviderRequest(dataRequest);
         manager.stop();

--- a/docs/developer/modules.md
+++ b/docs/developer/modules.md
@@ -79,6 +79,7 @@ org.eclipse.dataspaceconnector:jetty-micrometer:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:iam-daps:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:decentralized-identity:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:iam-mock:0.0.1-SNAPSHOT
+org.eclipse.dataspaceconnector:ids-policy:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:asset-index-sql:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:common-sql:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:contractdefinition-store-sql:0.0.1-SNAPSHOT

--- a/docs/developer/modules.md
+++ b/docs/developer/modules.md
@@ -79,7 +79,6 @@ org.eclipse.dataspaceconnector:jetty-micrometer:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:iam-daps:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:decentralized-identity:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:iam-mock:0.0.1-SNAPSHOT
-org.eclipse.dataspaceconnector:ids-policy:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:asset-index-sql:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:common-sql:0.0.1-SNAPSHOT
 org.eclipse.dataspaceconnector:contractdefinition-store-sql:0.0.1-SNAPSHOT

--- a/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/transfer/store/cosmos/CosmosTransferProcessStoreIntegrationTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -65,6 +66,7 @@ class CosmosTransferProcessStoreIntegrationTest {
     private static final String CONTAINER_PREFIX = "container_";
     private static CosmosContainer container;
     private static CosmosDatabase database;
+    private final Clock clock = Clock.systemUTC();
     private final String partitionKey = "testpartition";
     private final String connectorId = "test-connector";
     private CosmosTransferProcessStore store;
@@ -170,7 +172,7 @@ class CosmosTransferProcessStoreIntegrationTest {
         var tp = createTransferProcess(id1, TransferProcessStates.INITIAL);
         TransferProcessDocument item = new TransferProcessDocument(tp, partitionKey);
         Duration leaseDuration = Duration.ofSeconds(10);
-        item.acquireLease("another-connector", leaseDuration);
+        item.acquireLease("another-connector", clock, leaseDuration);
         container.upsertItem(item);
 
         List<TransferProcess> processesBeforeLeaseBreak = store.nextForState(TransferProcessStates.INITIAL.code(), 10);
@@ -197,7 +199,7 @@ class CosmosTransferProcessStoreIntegrationTest {
         store.create(tp);
         store.create(tp2);
         TransferProcessDocument item = readDocument(id2);
-        item.acquireLease("test-leaser");
+        item.acquireLease("test-leaser", clock);
         container.upsertItem(item);
 
         //act - one should be ignored
@@ -210,7 +212,7 @@ class CosmosTransferProcessStoreIntegrationTest {
     void nextForState_selfCannotLeaseAgain() {
         var tp1 = createTransferProcess("process1", TransferProcessStates.INITIAL);
         var doc = new TransferProcessDocument(tp1, partitionKey);
-        doc.acquireLease(connectorId);
+        doc.acquireLease(connectorId, clock);
         var originalTimestamp = doc.getLease().getLeasedAt();
         container.upsertItem(doc);
 
@@ -233,9 +235,9 @@ class CosmosTransferProcessStoreIntegrationTest {
         var tp2 = createTransferProcess(id2, TransferProcessStates.INITIAL);
 
         var d1 = new TransferProcessDocument(tp, partitionKey);
-        d1.acquireLease("another-connector");
+        d1.acquireLease("another-connector", clock);
         var d2 = new TransferProcessDocument(tp2, partitionKey);
-        d2.acquireLease("a-third-connector");
+        d2.acquireLease("a-third-connector", clock);
 
         container.upsertItem(d1);
         container.upsertItem(d2);
@@ -417,7 +419,7 @@ class CosmosTransferProcessStoreIntegrationTest {
 
         var doc = new TransferProcessDocument(tp, partitionKey);
         container.upsertItem(doc).getItem();
-        doc.acquireLease(connectorId);
+        doc.acquireLease(connectorId, clock);
         container.upsertItem(doc);
 
         tp.transitionProvisioning(ResourceManifest.Builder.newInstance().build());
@@ -434,7 +436,7 @@ class CosmosTransferProcessStoreIntegrationTest {
         var doc = new TransferProcessDocument(tp, partitionKey);
         container.upsertItem(doc).getItem();
 
-        doc.acquireLease("another-connector");
+        doc.acquireLease("another-connector", clock);
         container.upsertItem(doc);
 
         //act
@@ -461,7 +463,7 @@ class CosmosTransferProcessStoreIntegrationTest {
         final String processId = "test-process-id";
         var tp = createTransferProcess(processId);
         var doc = new TransferProcessDocument(tp, partitionKey);
-        doc.acquireLease("some-other-connector");
+        doc.acquireLease("some-other-connector", clock);
         container.upsertItem(doc);
 
         assertThatThrownBy(() -> store.delete(processId)).isInstanceOf(EdcException.class).hasRootCauseInstanceOf(BadRequestException.class);
@@ -472,7 +474,7 @@ class CosmosTransferProcessStoreIntegrationTest {
         final String processId = "test-process-id";
         var tp = createTransferProcess(processId);
         var doc = new TransferProcessDocument(tp, partitionKey);
-        doc.acquireLease(connectorId);
+        doc.acquireLease(connectorId, clock);
         container.upsertItem(doc);
 
         store.delete(processId);

--- a/extensions/azure/data-plane/data-factory/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azuredatafactory/DataPlaneAzureDataFactoryExtension.java
+++ b/extensions/azure/data-plane/data-factory/src/main/java/org/eclipse/dataspaceconnector/azure/dataplane/azuredatafactory/DataPlaneAzureDataFactoryExtension.java
@@ -61,8 +61,8 @@ public class DataPlaneAzureDataFactoryExtension implements ServiceExtension {
     @Inject
     private BlobStoreApi blobStoreApi;
 
-    @Inject(required = false)
-    private final Clock clock = Clock.systemUTC();
+    @Inject
+    private Clock clock;
 
     @Override
     public String name() {

--- a/extensions/data-plane-selector/selector-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/instance/DataPlaneInstance.java
+++ b/extensions/data-plane-selector/selector-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/instance/DataPlaneInstance.java
@@ -51,9 +51,9 @@ public interface DataPlaneInstance extends Polymorphic {
     int getTurnCount();
 
     /**
-     * The last time a particular instance was selected in POSIX time. If it has never been selected before, this returns null.
+     * The last time a particular instance was selected in POSIX time. If it has never been selected before, this returns 0.
      */
-    Long getLastActive();
+    long getLastActive();
 
     /**
      * A list of extensible properties, for example this could contain a DPF's public-facing API.

--- a/extensions/data-plane-selector/selector-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/instance/DataPlaneInstance.java
+++ b/extensions/data-plane-selector/selector-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/instance/DataPlaneInstance.java
@@ -51,9 +51,9 @@ public interface DataPlaneInstance extends Polymorphic {
     int getTurnCount();
 
     /**
-     * The last time a particular instance was selected in POSIX time. If it has never been selected before, this returns 0.
+     * The last time a particular instance was selected in POSIX time. If it has never been selected before, this returns null.
      */
-    long getLastActive();
+    Long getLastActive();
 
     /**
      * A list of extensible properties, for example this could contain a DPF's public-facing API.

--- a/extensions/data-plane-selector/selector-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/instance/DataPlaneInstanceImpl.java
+++ b/extensions/data-plane-selector/selector-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/instance/DataPlaneInstanceImpl.java
@@ -24,6 +24,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -46,12 +47,13 @@ public class DataPlaneInstanceImpl implements DataPlaneInstance {
     @JsonProperty("allowedDestTypes")
     private Set<String> allowedDestTypes;
     private int turnCount;
-    private Long lastActive;
+    private long lastActive;
     private URL url;
     private String id;
 
     private DataPlaneInstanceImpl() {
         turnCount = 0;
+        lastActive = Instant.now().toEpochMilli();
         properties = new HashMap<>();
         url = null;
 
@@ -90,7 +92,7 @@ public class DataPlaneInstanceImpl implements DataPlaneInstance {
     }
 
     @Override
-    public Long getLastActive() {
+    public long getLastActive() {
         return lastActive;
     }
 

--- a/extensions/data-plane-selector/selector-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/instance/DataPlaneInstanceImpl.java
+++ b/extensions/data-plane-selector/selector-spi/src/main/java/org/eclipse/dataspaceconnector/dataplane/selector/instance/DataPlaneInstanceImpl.java
@@ -24,7 +24,6 @@ import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -47,13 +46,12 @@ public class DataPlaneInstanceImpl implements DataPlaneInstance {
     @JsonProperty("allowedDestTypes")
     private Set<String> allowedDestTypes;
     private int turnCount;
-    private long lastActive;
+    private Long lastActive;
     private URL url;
     private String id;
 
     private DataPlaneInstanceImpl() {
         turnCount = 0;
-        lastActive = Instant.now().toEpochMilli();
         properties = new HashMap<>();
         url = null;
 
@@ -92,7 +90,7 @@ public class DataPlaneInstanceImpl implements DataPlaneInstance {
     }
 
     @Override
-    public long getLastActive() {
+    public Long getLastActive() {
         return lastActive;
     }
 

--- a/extensions/data-plane-selector/selector-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/strategy/RandomSelectionStrategyTest.java
+++ b/extensions/data-plane-selector/selector-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/strategy/RandomSelectionStrategyTest.java
@@ -15,15 +15,18 @@
 package org.eclipse.dataspaceconnector.dataplane.selector.strategy;
 
 import org.eclipse.dataspaceconnector.dataplane.selector.instance.DataPlaneInstance;
+import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 
-import java.util.Collections;
+import java.net.URL;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.Mockito.mock;
 
 class RandomSelectionStrategyTest {
     private static List<DataPlaneInstance> instances;
@@ -31,7 +34,41 @@ class RandomSelectionStrategyTest {
 
     @BeforeAll
     static void prepare() {
-        instances = Collections.nCopies(1000, mock(DataPlaneInstance.class));
+        instances = IntStream.range(0, 1000).mapToObj(RandomSelectionStrategyTest::createInstance).collect(Collectors.toList());
+    }
+
+    private static DataPlaneInstance createInstance(int i) {
+        return new DataPlaneInstance() {
+            @Override
+            public String getId() {
+                return null;
+            }
+
+            @Override
+            public boolean canHandle(DataAddress sourceAddress, DataAddress destinationAddress) {
+                return false;
+            }
+
+            @Override
+            public URL getUrl() {
+                return null;
+            }
+
+            @Override
+            public int getTurnCount() {
+                return 0;
+            }
+
+            @Override
+            public long getLastActive() {
+                return 0;
+            }
+
+            @Override
+            public Map<String, Object> getProperties() {
+                return null;
+            }
+        };
     }
 
     @BeforeEach

--- a/extensions/data-plane-selector/selector-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/strategy/RandomSelectionStrategyTest.java
+++ b/extensions/data-plane-selector/selector-spi/src/test/java/org/eclipse/dataspaceconnector/dataplane/selector/strategy/RandomSelectionStrategyTest.java
@@ -15,18 +15,15 @@
 package org.eclipse.dataspaceconnector.dataplane.selector.strategy;
 
 import org.eclipse.dataspaceconnector.dataplane.selector.instance.DataPlaneInstance;
-import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 
-import java.net.URL;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
 
 class RandomSelectionStrategyTest {
     private static List<DataPlaneInstance> instances;
@@ -34,41 +31,7 @@ class RandomSelectionStrategyTest {
 
     @BeforeAll
     static void prepare() {
-        instances = IntStream.range(0, 1000).mapToObj(RandomSelectionStrategyTest::createInstance).collect(Collectors.toList());
-    }
-
-    private static DataPlaneInstance createInstance(int i) {
-        return new DataPlaneInstance() {
-            @Override
-            public String getId() {
-                return null;
-            }
-
-            @Override
-            public boolean canHandle(DataAddress sourceAddress, DataAddress destinationAddress) {
-                return false;
-            }
-
-            @Override
-            public URL getUrl() {
-                return null;
-            }
-
-            @Override
-            public int getTurnCount() {
-                return 0;
-            }
-
-            @Override
-            public long getLastActive() {
-                return 0;
-            }
-
-            @Override
-            public Map<String, Object> getProperties() {
-                return null;
-            }
-        };
+        instances = Collections.nCopies(1000, mock(DataPlaneInstance.class));
     }
 
     @BeforeEach

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/proxy/DataPlaneTransferProxyReferenceServiceImpl.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/proxy/DataPlaneTransferProxyReferenceServiceImpl.java
@@ -24,7 +24,7 @@ import org.eclipse.dataspaceconnector.transfer.dataplane.spi.proxy.DataPlaneTran
 import org.eclipse.dataspaceconnector.transfer.dataplane.spi.security.DataEncrypter;
 import org.jetbrains.annotations.NotNull;
 
-import java.time.Instant;
+import java.time.Clock;
 import java.util.Date;
 import java.util.HashMap;
 
@@ -36,12 +36,14 @@ public class DataPlaneTransferProxyReferenceServiceImpl implements DataPlaneTran
     private final TypeManager typeManager;
     private final long tokenValiditySeconds;
     private final DataEncrypter dataEncrypter;
+    private final Clock clock;
 
-    public DataPlaneTransferProxyReferenceServiceImpl(TokenGenerationService tokenGenerationService, TypeManager typeManager, long tokenValiditySeconds, DataEncrypter dataEncrypter) {
+    public DataPlaneTransferProxyReferenceServiceImpl(TokenGenerationService tokenGenerationService, TypeManager typeManager, long tokenValiditySeconds, DataEncrypter dataEncrypter, Clock clock) {
         this.tokenGenerationService = tokenGenerationService;
         this.typeManager = typeManager;
         this.tokenValiditySeconds = tokenValiditySeconds;
         this.dataEncrypter = dataEncrypter;
+        this.clock = clock;
     }
 
     /**
@@ -51,7 +53,7 @@ public class DataPlaneTransferProxyReferenceServiceImpl implements DataPlaneTran
     @Override
     public Result<EndpointDataReference> createProxyReference(@NotNull DataPlaneTransferProxyCreationRequest request) {
         var encryptedDataAddress = dataEncrypter.encrypt(typeManager.writeValueAsString(request.getContentAddress()));
-        var decorator = new DataPlaneProxyTokenDecorator(Date.from(Instant.now().plusSeconds(tokenValiditySeconds)), request.getContractId(), encryptedDataAddress);
+        var decorator = new DataPlaneProxyTokenDecorator(Date.from(clock.instant().plusSeconds(tokenValiditySeconds)), request.getContractId(), encryptedDataAddress);
         var tokenGenerationResult = tokenGenerationService.generate(decorator);
         if (tokenGenerationResult.failed()) {
             return Result.failure(tokenGenerationResult.getFailureMessages());

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/validation/ContractValidationRule.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/validation/ContractValidationRule.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.text.ParseException;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.Map;
 
@@ -34,9 +35,11 @@ import static org.eclipse.dataspaceconnector.dataplane.spi.DataPlaneConstants.CO
 public class ContractValidationRule implements TokenValidationRule {
 
     private final ContractNegotiationStore contractNegotiationStore;
+    private final Clock clock;
 
-    public ContractValidationRule(ContractNegotiationStore contractNegotiationStore) {
+    public ContractValidationRule(ContractNegotiationStore contractNegotiationStore, Clock clock) {
         this.contractNegotiationStore = contractNegotiationStore;
+        this.clock = clock;
     }
 
     @Override
@@ -57,7 +60,7 @@ public class ContractValidationRule implements TokenValidationRule {
             return Result.failure("No contract agreement found for id: " + contractId);
         }
 
-        if (Instant.now().isAfter(Instant.ofEpochSecond(contractAgreement.getContractEndDate()))) {
+        if (clock.instant().isAfter(Instant.ofEpochSecond(contractAgreement.getContractEndDate()))) {
             return Result.failure("Contract has expired");
         }
 

--- a/extensions/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/validation/ExpirationDateValidationRule.java
+++ b/extensions/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/dataspaceconnector/transfer/dataplane/sync/validation/ExpirationDateValidationRule.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.text.ParseException;
-import java.time.Instant;
+import java.time.Clock;
 import java.util.Date;
 import java.util.Map;
 
@@ -29,6 +29,12 @@ import java.util.Map;
  * Assert that token containing these claims is not expired yet.
  */
 public class ExpirationDateValidationRule implements TokenValidationRule {
+
+    private final Clock clock;
+
+    public ExpirationDateValidationRule(Clock clock) {
+        this.clock = clock;
+    }
 
     @Override
     public Result<SignedJWT> checkRule(@NotNull SignedJWT toVerify, @Nullable Map<String, Object> additional) {
@@ -39,7 +45,7 @@ public class ExpirationDateValidationRule implements TokenValidationRule {
             }
 
             // check contract expiration date
-            if (Instant.now().isAfter(expiration.toInstant())) {
+            if (clock.instant().isAfter(expiration.toInstant())) {
                 return Result.failure("Token has expired");
             }
 

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/IdentityDidCoreExtension.java
@@ -43,6 +43,7 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.system.health.HealthCheckResult;
 import org.eclipse.dataspaceconnector.spi.system.health.HealthCheckService;
 
+import java.time.Clock;
 import java.util.function.Supplier;
 
 
@@ -57,6 +58,9 @@ public class IdentityDidCoreExtension implements ServiceExtension {
 
     @Inject
     private PrivateKeyResolver privateKeyResolver;
+
+    @Inject
+    private Clock clock;
 
     @Override
     public String name() {
@@ -102,7 +106,7 @@ public class IdentityDidCoreExtension implements ServiceExtension {
 
     @Provider(isDefault = true)
     public DidStore defaultDidDocumentStore() {
-        return new InMemoryDidDocumentStore();
+        return new InMemoryDidDocumentStore(clock);
     }
 
     private void registerParsers(PrivateKeyResolver resolver) {

--- a/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/store/InMemoryDidDocumentStore.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/dataspaceconnector/iam/did/store/InMemoryDidDocumentStore.java
@@ -18,6 +18,7 @@ import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;
 import org.eclipse.dataspaceconnector.iam.did.spi.store.DidStore;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
@@ -28,10 +29,12 @@ import java.util.stream.Collectors;
 
 public class InMemoryDidDocumentStore implements DidStore {
 
+    private final Clock clock;
     private final List<Entity<DidDocument>> memoryDb;
 
-    public InMemoryDidDocumentStore() {
-        memoryDb = new CopyOnWriteArrayList<>();
+    public InMemoryDidDocumentStore(Clock clock) {
+        this.clock = clock;
+        this.memoryDb = new CopyOnWriteArrayList<>();
     }
 
     @Override
@@ -83,8 +86,8 @@ public class InMemoryDidDocumentStore implements DidStore {
         return result.map(didDocumentEntity -> didDocumentEntity.payload).orElse(null);
     }
 
-    private static class Entity<T> implements Comparable<Entity<T>> {
-        private final Instant createTime = Instant.now();
+    private class Entity<T> implements Comparable<Entity<T>> {
+        private final Instant createTime = clock.instant();
         private final T payload;
 
         Entity(T payload) {

--- a/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/store/InMemoryDidDocumentStoreTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/dataspaceconnector/iam/did/store/InMemoryDidDocumentStoreTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.security.SecureRandom;
+import java.time.Clock;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Random;
@@ -35,7 +36,7 @@ class InMemoryDidDocumentStoreTest {
 
     @BeforeEach
     void setUp() {
-        store = new InMemoryDidDocumentStore();
+        store = new InMemoryDidDocumentStore(Clock.systemUTC());
     }
 
     @Test

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/credentials/VerifiableCredentialFactory.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/credentials/VerifiableCredentialFactory.java
@@ -46,10 +46,10 @@ public class VerifiableCredentialFactory {
 
     /**
      * Creates a signed JWT {@link SignedJWT} that contains a set of claims and an issuer.
-     * <p>
+     *
      * Although all private key types are possible, in the context of Distributed Identity and ION using an Elliptic Curve key ({@code prime256v1}) is advisable. This can be
      * achieved using OpenSSL CLI:
-     * <p>
+     *
      * {@code openssl ecparam -name prime256v1 -genkey -noout -out prime256v1-key.pem}
      *
      * @param privateKeyPemContent The contents of a private key stored in PEM format.
@@ -122,7 +122,7 @@ public class VerifiableCredentialFactory {
      * Verifies a VerifiableCredential using the issuer's public key
      *
      * @param verifiableCredential a {@link SignedJWT} that was sent by the claiming party.
-     * @param publicKey            The claiming party's public key
+     * @param publicKey The claiming party's public key
      * @return true if verified, false otherwise
      */
     public static boolean verify(SignedJWT verifiableCredential, ECKey publicKey) {
@@ -137,7 +137,7 @@ public class VerifiableCredentialFactory {
      * Verifies a VerifiableCredential using the issuer's public key
      *
      * @param verifiableCredential a {@link SignedJWT} that was sent by the claiming party.
-     * @param publicKey            The claiming party's public key, passed as a {@link PublicKeyWrapper}
+     * @param publicKey The claiming party's public key, passed as a {@link PublicKeyWrapper}
      * @return true if verified, false otherwise
      */
     public static boolean verify(SignedJWT verifiableCredential, PublicKeyWrapper publicKey) {
@@ -152,7 +152,7 @@ public class VerifiableCredentialFactory {
      * Verifies a VerifiableCredential using the issuer's public key
      *
      * @param verifiableCredential a {@link SignedJWT} that was sent by the claiming party.
-     * @param publicKeyPemContent  The claiming party's public key, i.e. the contents of the public key PEM file.
+     * @param publicKeyPemContent The claiming party's public key, i.e. the contents of the public key PEM file.
      * @return true if verified, false otherwise
      */
     public static boolean verify(SignedJWT verifiableCredential, String publicKeyPemContent) {

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/credentials/VerifiableCredentialFactory.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/credentials/VerifiableCredentialFactory.java
@@ -55,6 +55,7 @@ public class VerifiableCredentialFactory {
      * @param privateKeyPemContent The contents of a private key stored in PEM format.
      * @param claims a list of key-value-pairs that contain claims
      * @param issuer the "owner" of the VC, in most cases this will be the connector ID. The VC will store this in the "iss" claim
+     * @param clock clock used to get current time
      * @return a {@code SignedJWT} that is signed with the private key and contains all claims listed
      */
     public static SignedJWT create(String privateKeyPemContent, Map<String, String> claims, String issuer, Clock clock) {
@@ -73,6 +74,7 @@ public class VerifiableCredentialFactory {
      * @param privateKey A Private Key represented as {@link ECKey}.
      * @param claims a list of key-value-pairs that contain claims
      * @param issuer the "owner" of the VC, in most cases this will be the DID ID. The VC will store this in the "iss" claim
+     * @param clock clock used to get current time
      * @return a {@code SignedJWT} that is signed with the private key and contains all claims listed
      */
     public static SignedJWT create(ECKey privateKey, Map<String, String> claims, String issuer, Clock clock) {
@@ -86,6 +88,7 @@ public class VerifiableCredentialFactory {
      * @param privateKey A Private Key represented as {@link PrivateKeyWrapper}.
      * @param claims a list of key-value-pairs that contain claims
      * @param issuer the "owner" of the VC, in most cases this will be the DID ID. The VC will store this in the "iss" claim
+     * @param clock clock used to get current time
      * @return a {@code SignedJWT} that is signed with the private key and contains all claims listed
      */
     public static SignedJWT create(PrivateKeyWrapper privateKey, Map<String, String> claims, String issuer, Clock clock) {

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/credentials/VerifiableCredentialFactory.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/credentials/VerifiableCredentialFactory.java
@@ -53,9 +53,8 @@ public class VerifiableCredentialFactory {
      * {@code openssl ecparam -name prime256v1 -genkey -noout -out prime256v1-key.pem}
      *
      * @param privateKeyPemContent The contents of a private key stored in PEM format.
-     * @param claims               a list of key-value-pairs that contain claims
-     * @param issuer               the "owner" of the VC, in most cases this will be the connector ID. The VC will store this in the "iss" claim
-     * @param clock                clock used to get current time
+     * @param claims a list of key-value-pairs that contain claims
+     * @param issuer the "owner" of the VC, in most cases this will be the connector ID. The VC will store this in the "iss" claim
      * @return a {@code SignedJWT} that is signed with the private key and contains all claims listed
      */
     public static SignedJWT create(String privateKeyPemContent, Map<String, String> claims, String issuer, Clock clock) {
@@ -72,9 +71,8 @@ public class VerifiableCredentialFactory {
      * and ION using an Elliptic Curve key ({@code P-256}) is advisable.
      *
      * @param privateKey A Private Key represented as {@link ECKey}.
-     * @param claims     a list of key-value-pairs that contain claims
-     * @param issuer     the "owner" of the VC, in most cases this will be the DID ID. The VC will store this in the "iss" claim
-     * @param clock      clock used to get current time
+     * @param claims a list of key-value-pairs that contain claims
+     * @param issuer the "owner" of the VC, in most cases this will be the DID ID. The VC will store this in the "iss" claim
      * @return a {@code SignedJWT} that is signed with the private key and contains all claims listed
      */
     public static SignedJWT create(ECKey privateKey, Map<String, String> claims, String issuer, Clock clock) {
@@ -86,9 +84,8 @@ public class VerifiableCredentialFactory {
      * using an Elliptic Curve key ({@code P-256}) is advisable.
      *
      * @param privateKey A Private Key represented as {@link PrivateKeyWrapper}.
-     * @param claims     a list of key-value-pairs that contain claims
-     * @param issuer     the "owner" of the VC, in most cases this will be the DID ID. The VC will store this in the "iss" claim
-     * @param clock      clock used to get current time
+     * @param claims a list of key-value-pairs that contain claims
+     * @param issuer the "owner" of the VC, in most cases this will be the DID ID. The VC will store this in the "iss" claim
      * @return a {@code SignedJWT} that is signed with the private key and contains all claims listed
      */
     public static SignedJWT create(PrivateKeyWrapper privateKey, Map<String, String> claims, String issuer, Clock clock) {

--- a/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/credentials/VerifiableCredentialFactory.java
+++ b/extensions/iam/decentralized-identity/identity-did-crypto/src/main/java/org/eclipse/dataspaceconnector/iam/did/crypto/credentials/VerifiableCredentialFactory.java
@@ -29,7 +29,7 @@ import org.eclipse.dataspaceconnector.iam.did.spi.key.PrivateKeyWrapper;
 import org.eclipse.dataspaceconnector.iam.did.spi.key.PublicKeyWrapper;
 
 import java.text.ParseException;
-import java.time.Instant;
+import java.time.Clock;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.Date;
@@ -46,21 +46,22 @@ public class VerifiableCredentialFactory {
 
     /**
      * Creates a signed JWT {@link SignedJWT} that contains a set of claims and an issuer.
-     *
+     * <p>
      * Although all private key types are possible, in the context of Distributed Identity and ION using an Elliptic Curve key ({@code prime256v1}) is advisable. This can be
      * achieved using OpenSSL CLI:
-     *
+     * <p>
      * {@code openssl ecparam -name prime256v1 -genkey -noout -out prime256v1-key.pem}
      *
      * @param privateKeyPemContent The contents of a private key stored in PEM format.
-     * @param claims a list of key-value-pairs that contain claims
-     * @param issuer the "owner" of the VC, in most cases this will be the connector ID. The VC will store this in the "iss" claim
+     * @param claims               a list of key-value-pairs that contain claims
+     * @param issuer               the "owner" of the VC, in most cases this will be the connector ID. The VC will store this in the "iss" claim
+     * @param clock                clock used to get current time
      * @return a {@code SignedJWT} that is signed with the private key and contains all claims listed
      */
-    public static SignedJWT create(String privateKeyPemContent, Map<String, String> claims, String issuer) {
+    public static SignedJWT create(String privateKeyPemContent, Map<String, String> claims, String issuer, Clock clock) {
         try {
             var key = ECKey.parseFromPEMEncodedObjects(privateKeyPemContent);
-            return create((ECKey) key, claims, issuer);
+            return create((ECKey) key, claims, issuer, clock);
         } catch (JOSEException e) {
             throw new CryptoException(e);
         }
@@ -71,12 +72,13 @@ public class VerifiableCredentialFactory {
      * and ION using an Elliptic Curve key ({@code P-256}) is advisable.
      *
      * @param privateKey A Private Key represented as {@link ECKey}.
-     * @param claims a list of key-value-pairs that contain claims
-     * @param issuer the "owner" of the VC, in most cases this will be the DID ID. The VC will store this in the "iss" claim
+     * @param claims     a list of key-value-pairs that contain claims
+     * @param issuer     the "owner" of the VC, in most cases this will be the DID ID. The VC will store this in the "iss" claim
+     * @param clock      clock used to get current time
      * @return a {@code SignedJWT} that is signed with the private key and contains all claims listed
      */
-    public static SignedJWT create(ECKey privateKey, Map<String, String> claims, String issuer) {
-        return create(new EcPrivateKeyWrapper(privateKey), claims, issuer);
+    public static SignedJWT create(ECKey privateKey, Map<String, String> claims, String issuer, Clock clock) {
+        return create(new EcPrivateKeyWrapper(privateKey), claims, issuer, clock);
     }
 
     /**
@@ -84,17 +86,18 @@ public class VerifiableCredentialFactory {
      * using an Elliptic Curve key ({@code P-256}) is advisable.
      *
      * @param privateKey A Private Key represented as {@link PrivateKeyWrapper}.
-     * @param claims a list of key-value-pairs that contain claims
-     * @param issuer the "owner" of the VC, in most cases this will be the DID ID. The VC will store this in the "iss" claim
+     * @param claims     a list of key-value-pairs that contain claims
+     * @param issuer     the "owner" of the VC, in most cases this will be the DID ID. The VC will store this in the "iss" claim
+     * @param clock      clock used to get current time
      * @return a {@code SignedJWT} that is signed with the private key and contains all claims listed
      */
-    public static SignedJWT create(PrivateKeyWrapper privateKey, Map<String, String> claims, String issuer) {
+    public static SignedJWT create(PrivateKeyWrapper privateKey, Map<String, String> claims, String issuer, Clock clock) {
         var claimssetBuilder = new JWTClaimsSet.Builder();
 
         claims.forEach(claimssetBuilder::claim);
         var claimsSet = claimssetBuilder.issuer(issuer)
                 .subject("verifiable-credential")
-                .expirationTime(Date.from(Instant.now().plus(10, ChronoUnit.MINUTES)))
+                .expirationTime(Date.from(clock.instant().plus(10, ChronoUnit.MINUTES)))
                 .jwtID(UUID.randomUUID().toString())
                 .build();
 
@@ -119,7 +122,7 @@ public class VerifiableCredentialFactory {
      * Verifies a VerifiableCredential using the issuer's public key
      *
      * @param verifiableCredential a {@link SignedJWT} that was sent by the claiming party.
-     * @param publicKey The claiming party's public key
+     * @param publicKey            The claiming party's public key
      * @return true if verified, false otherwise
      */
     public static boolean verify(SignedJWT verifiableCredential, ECKey publicKey) {
@@ -134,7 +137,7 @@ public class VerifiableCredentialFactory {
      * Verifies a VerifiableCredential using the issuer's public key
      *
      * @param verifiableCredential a {@link SignedJWT} that was sent by the claiming party.
-     * @param publicKey The claiming party's public key, passed as a {@link PublicKeyWrapper}
+     * @param publicKey            The claiming party's public key, passed as a {@link PublicKeyWrapper}
      * @return true if verified, false otherwise
      */
     public static boolean verify(SignedJWT verifiableCredential, PublicKeyWrapper publicKey) {
@@ -149,7 +152,7 @@ public class VerifiableCredentialFactory {
      * Verifies a VerifiableCredential using the issuer's public key
      *
      * @param verifiableCredential a {@link SignedJWT} that was sent by the claiming party.
-     * @param publicKeyPemContent The claiming party's public key, i.e. the contents of the public key PEM file.
+     * @param publicKeyPemContent  The claiming party's public key, i.e. the contents of the public key PEM file.
      * @return true if verified, false otherwise
      */
     public static boolean verify(SignedJWT verifiableCredential, String publicKeyPemContent) {
@@ -174,12 +177,5 @@ public class VerifiableCredentialFactory {
         } catch (ParseException e) {
             throw new CryptoException(e);
         }
-    }
-
-    /**
-     * A helper method to construct the name of the secret in the vault, which contains the VC.
-     */
-    public static String getVaultSecretName(String issuer) {
-        return issuer + "-vc";
     }
 }

--- a/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityService.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityService.java
@@ -34,7 +34,7 @@ import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 
 import java.text.ParseException;
-import java.util.Date;
+import java.time.Clock;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -44,12 +44,14 @@ public class DecentralizedIdentityService implements IdentityService {
     private final DidResolverRegistry resolverRegistry;
     private final CredentialsVerifier credentialsVerifier;
     private final Monitor monitor;
+    private final Clock clock;
 
-    public DecentralizedIdentityService(Supplier<SignedJWT> vcProvider, DidResolverRegistry resolverRegistry, CredentialsVerifier credentialsVerifier, Monitor monitor) {
+    public DecentralizedIdentityService(Supplier<SignedJWT> vcProvider, DidResolverRegistry resolverRegistry, CredentialsVerifier credentialsVerifier, Monitor monitor, Clock clock) {
         verifiableCredentialProvider = vcProvider;
         this.resolverRegistry = resolverRegistry;
         this.credentialsVerifier = credentialsVerifier;
         this.monitor = monitor;
+        this.clock = clock;
     }
 
     @Override
@@ -57,7 +59,7 @@ public class DecentralizedIdentityService implements IdentityService {
 
         var jwt = verifiableCredentialProvider.get();
         var token = jwt.serialize();
-        var expiration = new Date().getTime() + TimeUnit.MINUTES.toMillis(10);
+        var expiration = clock.millis() + TimeUnit.MINUTES.toMillis(10);
 
         return Result.success(TokenRepresentation.Builder.newInstance().token(token).expiresIn(expiration).build());
     }

--- a/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceExtension.java
@@ -54,7 +54,7 @@ public class DecentralizedIdentityServiceExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var vcProvider = createSupplier(context);
-        var identityService = new DecentralizedIdentityService(vcProvider, resolverRegistry, credentialsVerifier, context.getMonitor());
+        var identityService = new DecentralizedIdentityService(vcProvider, resolverRegistry, credentialsVerifier, context.getMonitor(), context.getClock());
         context.registerService(IdentityService.class, identityService);
     }
 

--- a/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceExtension.java
@@ -27,6 +27,7 @@ import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
+import java.time.Clock;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -45,6 +46,9 @@ public class DecentralizedIdentityServiceExtension implements ServiceExtension {
 
     @Inject
     private PrivateKeyResolver privateKeyResolver;
+
+    @Inject
+    private Clock clock;
 
     @Override
     public String name() {
@@ -77,7 +81,7 @@ public class DecentralizedIdentityServiceExtension implements ServiceExtension {
 
             // we cannot store the VerifiableCredential in the Vault, because it has an expiry date
             // the Issuer claim must contain the DID URL
-            return VerifiableCredentialFactory.create(privateKeyString, Map.of(VerifiableCredentialFactory.OWNER_CLAIM, connectorName), didUrl);
+            return VerifiableCredentialFactory.create(privateKeyString, Map.of(VerifiableCredentialFactory.OWNER_CLAIM, connectorName), didUrl, clock);
         };
     }
 }

--- a/extensions/iam/decentralized-identity/identity-did-service/src/test/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/test/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -115,7 +116,7 @@ abstract class DecentralizedIdentityServiceTest {
 
         CredentialsVerifier verifier = (document, url) -> Result.success(Map.of("region", "eu"));
         Supplier<SignedJWT> signedJwtSupplier = () -> VerifiableCredentialFactory.create(privateKey, Map.of("region", "us"), "test-issuer");
-        identityService = new DecentralizedIdentityService(signedJwtSupplier, didResolver, verifier, mock(Monitor.class));
+        identityService = new DecentralizedIdentityService(signedJwtSupplier, didResolver, verifier, mock(Monitor.class), Clock.systemUTC());
 
     }
 

--- a/extensions/iam/decentralized-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/crawler/CrawlerContext.java
+++ b/extensions/iam/decentralized-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/crawler/CrawlerContext.java
@@ -20,6 +20,8 @@ import org.eclipse.dataspaceconnector.iam.registrationservice.events.CrawlerEven
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 
+import java.time.Clock;
+
 /**
  * Stores parameters (such as the DID Type) and necessary objects (such as the IonClient or the DidStore)
  * for the crawler, so it is essentially a Holder which is passed through to the {@link CrawlerJob} by Quartz
@@ -33,6 +35,7 @@ public class CrawlerContext {
     private String didTypes;
     private DidResolverRegistry resolverRegistry;
     private TypeManager typeManager;
+    private Clock clock;
 
     public DidStore getDidStore() {
         return didStore;
@@ -62,6 +65,10 @@ public class CrawlerContext {
         return typeManager;
     }
 
+    public Clock getClock() {
+        return clock;
+    }
+
     public static final class Builder {
         private DidStore didStore;
         private Monitor monitor;
@@ -70,6 +77,7 @@ public class CrawlerContext {
         private String didTypes;
         private DidResolverRegistry resolverRegistry;
         private TypeManager typeManager;
+        private Clock clock;
 
         private Builder() {
         }
@@ -113,12 +121,18 @@ public class CrawlerContext {
             return this;
         }
 
+        public Builder clock(Clock clock) {
+            this.clock = clock;
+            return this;
+        }
+
         public CrawlerContext build() {
             CrawlerContext crawlerConfig = new CrawlerContext();
             crawlerConfig.didTypes = didTypes;
             crawlerConfig.ionHost = ionHost;
             crawlerConfig.publisher = publisher;
             crawlerConfig.typeManager = typeManager;
+            crawlerConfig.clock = clock;
             crawlerConfig.didStore = didStore;
             crawlerConfig.monitor = monitor;
             crawlerConfig.resolverRegistry = resolverRegistry;

--- a/extensions/iam/decentralized-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/crawler/CrawlerExtension.java
+++ b/extensions/iam/decentralized-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/crawler/CrawlerExtension.java
@@ -31,6 +31,7 @@ import org.quartz.SchedulerException;
 import org.quartz.Trigger;
 import org.quartz.impl.StdSchedulerFactory;
 
+import java.time.Clock;
 import java.util.Map;
 
 import static org.quartz.JobBuilder.newJob;
@@ -53,6 +54,8 @@ public class CrawlerExtension implements ServiceExtension {
     private DidResolverRegistry resolverRegistry;
     @Inject
     private Vault vault;
+    @Inject
+    private Clock clock;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
@@ -99,6 +102,7 @@ public class CrawlerExtension implements ServiceExtension {
                 .ionHost(context.getSetting(ION_URL_SETTING, "http://gx-ion-node.westeurope.cloudapp.azure.com:3000/"))
                 .monitor(context.getMonitor())
                 .typeManager(context.getTypeManager())
+                .clock(clock)
                 .publisher(publisher)
                 .didTypes(context.getSetting(ION_CRAWLER_TYPE_SETTING, "aW9u"))
                 .resolverRegistry(resolverRegistry)

--- a/extensions/iam/decentralized-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/crawler/CrawlerJob.java
+++ b/extensions/iam/decentralized-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/crawler/CrawlerJob.java
@@ -41,7 +41,6 @@ import static java.lang.String.format;
 public class CrawlerJob implements Job {
 
     private static final String DIDS_PATH = "dids";
-    private static final Clock CLOCK = Clock.systemUTC();
     private String ionApiUrl;
 
     /**
@@ -60,7 +59,8 @@ public class CrawlerJob implements Job {
 
         monitor.info("CrawlerJob: browsing ION to obtain GaiaX DIDs");
 
-        var start = CLOCK.instant();
+        var clock = cc.getClock();
+        var start = clock.instant();
         var newDidFutures = getDidDocumentsFromBlockchainAsync(cc);
 
         List<DidDocument> newDids = newDidFutures.parallelStream()
@@ -70,7 +70,7 @@ public class CrawlerJob implements Job {
                 .map(Result::getContent)
                 .collect(Collectors.toList());
 
-        monitor.info("CrawlerJob: Found " + newDids.size() + " new DIDs on ION, took " + (Duration.between(start, CLOCK.instant()).toString()
+        monitor.info("CrawlerJob: Found " + newDids.size() + " new DIDs on ION, took " + (Duration.between(start, clock.instant()).toString()
                 .substring(2)
                 .replaceAll("(\\d[HMS])(?!$)", "$1 ")
                 .toLowerCase()));

--- a/extensions/iam/decentralized-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/crawler/CrawlerJob.java
+++ b/extensions/iam/decentralized-identity/registration-service/src/main/java/org/eclipse/dataspaceconnector/iam/registrationservice/crawler/CrawlerJob.java
@@ -115,8 +115,7 @@ public class CrawlerJob implements Job {
         try (var response = client.newCall(request).execute()) {
             if (response.isSuccessful()) {
                 var json = Objects.requireNonNull(response.body()).string();
-                var typeReference = new TypeReference<List<String>>() {
-                };
+                var typeReference = new TypeReference<List<String>>() {};
                 return typeManager.readValue(json, typeReference);
             } else {
                 throw new EdcException(format("Could not get DIDs: error=%s, message=%s", response.code(), response.body().string()));

--- a/extensions/iam/iam-mock/src/main/java/org/eclipse/dataspaceconnector/iam/mock/IamMockExtension.java
+++ b/extensions/iam/iam-mock/src/main/java/org/eclipse/dataspaceconnector/iam/mock/IamMockExtension.java
@@ -33,6 +33,6 @@ public class IamMockExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var region = context.getSetting("edc.mock.region", "eu");
-        context.registerService(IdentityService.class, new MockIdentityService(region));
+        context.registerService(IdentityService.class, new MockIdentityService(context.getClock(), region));
     }
 }

--- a/extensions/iam/iam-mock/src/main/java/org/eclipse/dataspaceconnector/iam/mock/MockIdentityService.java
+++ b/extensions/iam/iam-mock/src/main/java/org/eclipse/dataspaceconnector/iam/mock/MockIdentityService.java
@@ -20,12 +20,14 @@ import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.iam.TokenRepresentation;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 
-import java.time.Instant;
+import java.time.Clock;
 
 public class MockIdentityService implements IdentityService {
     private final String region;
+    private final Clock clock;
 
-    public MockIdentityService(String region) {
+    public MockIdentityService(Clock clock, String region) {
+        this.clock = clock;
         this.region = region;
     }
 
@@ -33,7 +35,7 @@ public class MockIdentityService implements IdentityService {
     public Result<TokenRepresentation> obtainClientCredentials(String scope) {
         TokenRepresentation tokenRepresentation = TokenRepresentation.Builder.newInstance()
                 .token("mock-" + region)
-                .expiresIn(Instant.now().plusSeconds(10_0000).toEpochMilli())
+                .expiresIn(clock.instant().plusSeconds(10_0000).toEpochMilli())
                 .build();
         return Result.success(tokenRepresentation);
     }

--- a/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/Oauth2Extension.java
+++ b/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/Oauth2Extension.java
@@ -97,7 +97,7 @@ public class Oauth2Extension implements ServiceExtension {
 
         var configuration = createConfig(context);
 
-        var defaultDecorator = new DefaultJwtDecorator(configuration.getProviderAudience(), configuration.getClientId(), getEncodedClientCertificate(configuration), TOKEN_EXPIRATION);
+        var defaultDecorator = new DefaultJwtDecorator(configuration.getProviderAudience(), configuration.getClientId(), getEncodedClientCertificate(configuration), context.getClock(), TOKEN_EXPIRATION);
         var jwtDecoratorRegistry = new Oauth2JwtDecoratorRegistryRegistryImpl();
         jwtDecoratorRegistry.register(defaultDecorator);
         context.registerService(Oauth2JwtDecoratorRegistry.class, jwtDecoratorRegistry);

--- a/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/Oauth2Extension.java
+++ b/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/Oauth2Extension.java
@@ -38,6 +38,7 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
 import java.security.PrivateKey;
 import java.security.cert.CertificateEncodingException;
+import java.time.Clock;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -83,6 +84,9 @@ public class Oauth2Extension implements ServiceExtension {
     @Inject
     private CertificateResolver certificateResolver;
 
+    @Inject
+    private Clock clock;
+
     @Override
     public String name() {
         return "OAuth2";
@@ -102,7 +106,7 @@ public class Oauth2Extension implements ServiceExtension {
         jwtDecoratorRegistry.register(defaultDecorator);
         context.registerService(Oauth2JwtDecoratorRegistry.class, jwtDecoratorRegistry);
 
-        var validationRulesRegistry = new Oauth2ValidationRulesRegistryImpl(configuration);
+        var validationRulesRegistry = new Oauth2ValidationRulesRegistryImpl(configuration, clock);
         context.registerService(Oauth2ValidationRulesRegistry.class, validationRulesRegistry);
 
         var tokenValidationService = new TokenValidationServiceImpl(configuration.getIdentityProviderKeyResolver(), validationRulesRegistry);

--- a/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/jwt/DefaultJwtDecorator.java
+++ b/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/jwt/DefaultJwtDecorator.java
@@ -19,7 +19,7 @@ import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.JWTClaimsSet;
 import org.eclipse.dataspaceconnector.common.token.JwtDecorator;
 
-import java.time.Instant;
+import java.time.Clock;
 import java.util.Date;
 import java.util.UUID;
 
@@ -30,12 +30,14 @@ public class DefaultJwtDecorator implements JwtDecorator {
     private final String audience;
     private final String clientId;
     private final byte[] encodedCertificate;
+    private final Clock clock;
     private final long expiration;
 
-    public DefaultJwtDecorator(String audience, String clientId, byte[] encodedCertificate, long expiration) {
+    public DefaultJwtDecorator(String audience, String clientId, byte[] encodedCertificate, Clock clock, long expiration) {
         this.audience = audience;
         this.clientId = clientId;
         this.encodedCertificate = encodedCertificate;
+        this.clock = clock;
         this.expiration = expiration;
     }
 
@@ -46,8 +48,7 @@ public class DefaultJwtDecorator implements JwtDecorator {
                 .issuer(clientId)
                 .subject(clientId)
                 .jwtID(UUID.randomUUID().toString())
-                .notBeforeTime(new Date())
-                .issueTime(new Date())
-                .expirationTime(Date.from(Instant.now().plusSeconds(expiration)));
+                .issueTime(Date.from(clock.instant()))
+                .expirationTime(Date.from(clock.instant().plusSeconds(expiration)));
     }
 }

--- a/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2ValidationRulesRegistryImpl.java
+++ b/extensions/iam/oauth2/oauth2-core/src/main/java/org/eclipse/dataspaceconnector/iam/oauth2/core/rule/Oauth2ValidationRulesRegistryImpl.java
@@ -18,12 +18,14 @@ import org.eclipse.dataspaceconnector.common.token.TokenValidationRulesRegistryI
 import org.eclipse.dataspaceconnector.iam.oauth2.core.Oauth2Configuration;
 import org.eclipse.dataspaceconnector.iam.oauth2.spi.Oauth2ValidationRulesRegistry;
 
+import java.time.Clock;
+
 /**
  * Registry for Oauth2 validation rules.
  */
 public class Oauth2ValidationRulesRegistryImpl extends TokenValidationRulesRegistryImpl implements Oauth2ValidationRulesRegistry {
 
-    public Oauth2ValidationRulesRegistryImpl(Oauth2Configuration configuration) {
-        this.addRule(new Oauth2ValidationRule(configuration));
+    public Oauth2ValidationRulesRegistryImpl(Oauth2Configuration configuration, Clock clock) {
+        this.addRule(new Oauth2ValidationRule(configuration, clock));
     }
 }

--- a/extensions/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/identity/Oauth2ServiceImplTest.java
+++ b/extensions/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/identity/Oauth2ServiceImplTest.java
@@ -37,10 +37,12 @@ import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.util.Date;
 import java.util.UUID;
 
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.common.testfixtures.TestUtils.testOkHttpClient;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -55,6 +57,7 @@ class Oauth2ServiceImplTest {
     private static final String PUBLIC_CERTIFICATE_ALIAS = "cert-test";
     private static final String PROVIDER_AUDIENCE = "audience-test";
 
+    private Instant now = Instant.now();
     private Oauth2ServiceImpl authService;
     private JWSSigner jwsSigner;
 
@@ -78,7 +81,8 @@ class Oauth2ServiceImplTest {
                 .identityProviderKeyResolver(publicKeyResolverMock)
                 .build();
 
-        var validationRulesRegistry = new Oauth2ValidationRulesRegistryImpl(configuration);
+        var clock = Clock.fixed(now, UTC);
+        var validationRulesRegistry = new Oauth2ValidationRulesRegistryImpl(configuration, clock);
         var tokenValidationService = new TokenValidationServiceImpl(publicKeyResolverMock, validationRulesRegistry);
 
         authService = new Oauth2ServiceImpl(configuration, mock(TokenGenerationService.class), testOkHttpClient(), new JwtDecoratorRegistryImpl(), new TypeManager(), tokenValidationService);
@@ -86,7 +90,7 @@ class Oauth2ServiceImplTest {
 
     @Test
     void verifyNoAudienceToken() {
-        var jwt = createJwt(null, Date.from(Instant.now().minusSeconds(1000)), Date.from(Instant.now().plusSeconds(1000)));
+        var jwt = createJwt(null, Date.from(now.minusSeconds(1000)), Date.from(now.plusSeconds(1000)));
 
         var result = authService.verifyJwtToken(jwt.serialize());
 
@@ -96,7 +100,7 @@ class Oauth2ServiceImplTest {
 
     @Test
     void verifyInvalidAudienceToken() {
-        var jwt = createJwt("different.audience", Date.from(Instant.now().minusSeconds(1000)), Date.from(Instant.now().plusSeconds(1000)));
+        var jwt = createJwt("different.audience", Date.from(now.minusSeconds(1000)), Date.from(now.plusSeconds(1000)));
 
         var result = authService.verifyJwtToken(jwt.serialize());
 
@@ -106,7 +110,7 @@ class Oauth2ServiceImplTest {
 
     @Test
     void verifyInvalidAttemptUseNotBeforeToken() {
-        var jwt = createJwt(PROVIDER_AUDIENCE, Date.from(Instant.now().plusSeconds(1000)), Date.from(Instant.now().plusSeconds(1000)));
+        var jwt = createJwt(PROVIDER_AUDIENCE, Date.from(now.plusSeconds(1000)), Date.from(now.plusSeconds(1000)));
 
         var result = authService.verifyJwtToken(jwt.serialize());
 
@@ -116,7 +120,7 @@ class Oauth2ServiceImplTest {
 
     @Test
     void verifyExpiredToken() {
-        var jwt = createJwt(PROVIDER_AUDIENCE, Date.from(Instant.now().minusSeconds(1000)), Date.from(Instant.now().minusSeconds(1000)));
+        var jwt = createJwt(PROVIDER_AUDIENCE, Date.from(now.minusSeconds(1000)), Date.from(now.minusSeconds(1000)));
 
         var result = authService.verifyJwtToken(jwt.serialize());
 
@@ -126,7 +130,7 @@ class Oauth2ServiceImplTest {
 
     @Test
     void verifyValidJwt() {
-        var jwt = createJwt(PROVIDER_AUDIENCE, Date.from(Instant.now().minusSeconds(1000)), new Date(System.currentTimeMillis() + 1000000));
+        var jwt = createJwt(PROVIDER_AUDIENCE, Date.from(now.minusSeconds(1000)), new Date(System.currentTimeMillis() + 1000000));
 
         var result = authService.verifyJwtToken(jwt.serialize());
 

--- a/extensions/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/jwt/Oauth2ValidationRuleTest.java
+++ b/extensions/iam/oauth2/oauth2-core/src/test/java/org/eclipse/dataspaceconnector/iam/oauth2/core/jwt/Oauth2ValidationRuleTest.java
@@ -24,22 +24,25 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Date;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class Oauth2ValidationRuleTest {
 
     public static final String TEST_AUDIENCE = "test-audience";
     private final Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+    private final Clock clock = Clock.fixed(now, UTC);
     private Oauth2ValidationRule rule;
     private JWSHeader jwsHeader;
 
     @BeforeEach
     public void setUp() {
         var configuration = Oauth2Configuration.Builder.newInstance().providerAudience("test-audience").build();
-        rule = new Oauth2ValidationRule(configuration);
+        rule = new Oauth2ValidationRule(configuration, clock);
         jwsHeader = new JWSHeader.Builder(JWSAlgorithm.RS256).build();
     }
 
@@ -147,7 +150,7 @@ class Oauth2ValidationRuleTest {
                 .providerAudience(TEST_AUDIENCE)
                 .notBeforeValidationLeeway(20)
                 .build();
-        rule = new Oauth2ValidationRule(configuration);
+        rule = new Oauth2ValidationRule(configuration, clock);
 
         var jwt = new SignedJWT(jwsHeader, claims);
         var result = rule.checkRule(jwt);

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/SqlContractNegotiationStoreExtension.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/SqlContractNegotiationStoreExtension.java
@@ -25,6 +25,8 @@ import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.ContractNego
 import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.PostgresStatements;
 import org.eclipse.dataspaceconnector.sql.contractnegotiation.store.SqlContractNegotiationStore;
 
+import java.time.Clock;
+
 @Provides({ ContractNegotiationStore.class })
 public class SqlContractNegotiationStoreExtension implements ServiceExtension {
 
@@ -37,12 +39,15 @@ public class SqlContractNegotiationStoreExtension implements ServiceExtension {
     @Inject
     private TransactionContext trxContext;
 
+    @Inject
+    private Clock clock;
+
     @Inject(required = false)
     private ContractNegotiationStatements statements;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var sqlStore = new SqlContractNegotiationStore(dataSourceRegistry, getDataSourceName(context), trxContext, context.getTypeManager(), getStatementImpl(), context.getConnectorId());
+        var sqlStore = new SqlContractNegotiationStore(dataSourceRegistry, getDataSourceName(context), trxContext, context.getTypeManager(), getStatementImpl(), context.getConnectorId(), clock);
         context.registerService(ContractNegotiationStore.class, sqlStore);
     }
 

--- a/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.Nullable;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
@@ -53,13 +54,13 @@ public class SqlContractNegotiationStore implements ContractNegotiationStore {
     private final ContractNegotiationStatements statements;
     private final SqlLeaseContextBuilder leaseContext;
 
-    public SqlContractNegotiationStore(DataSourceRegistry dataSourceRegistry, String dataSourceName, TransactionContext transactionContext, TypeManager manager, ContractNegotiationStatements statements, String connectorId) {
+    public SqlContractNegotiationStore(DataSourceRegistry dataSourceRegistry, String dataSourceName, TransactionContext transactionContext, TypeManager manager, ContractNegotiationStatements statements, String connectorId, Clock clock) {
         typeManager = manager;
         this.dataSourceRegistry = dataSourceRegistry;
         this.dataSourceName = dataSourceName;
         this.transactionContext = transactionContext;
         this.statements = statements;
-        leaseContext = SqlLeaseContextBuilder.with(transactionContext, connectorId, statements);
+        leaseContext = SqlLeaseContextBuilder.with(transactionContext, connectorId, statements, clock);
     }
 
     @Override

--- a/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
+++ b/extensions/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/contractnegotiation/store/SqlContractNegotiationStoreTest.java
@@ -37,6 +37,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.UUID;
@@ -85,12 +86,12 @@ class SqlContractNegotiationStoreTest {
         TypeManager manager = new TypeManager();
 
         manager.registerTypes(PolicyRegistrationTypes.TYPES.toArray(Class<?>[]::new));
-        store = new SqlContractNegotiationStore(dataSourceRegistry, DATASOURCE_NAME, txManager, manager, statements, CONNECTOR_NAME);
+        store = new SqlContractNegotiationStore(dataSourceRegistry, DATASOURCE_NAME, txManager, manager, statements, CONNECTOR_NAME, Clock.systemUTC());
 
         var schema = Files.readString(Paths.get("./docs/schema.sql"));
         txManager.execute(() -> SqlQueryExecutor.executeQuery(connection, schema));
 
-        leaseUtil = new LeaseUtil(txManager, this::getConnection, statements);
+        leaseUtil = new LeaseUtil(txManager, this::getConnection, statements, Clock.systemUTC());
     }
 
     @AfterEach

--- a/extensions/sql/lease-sql/src/main/java/org/eclipse/dataspaceconnector/sql/lease/SqlLease.java
+++ b/extensions/sql/lease-sql/src/main/java/org/eclipse/dataspaceconnector/sql/lease/SqlLease.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.sql.lease;
 
 import org.eclipse.dataspaceconnector.spi.persistence.Lease;
 
+import java.time.Clock;
 import java.time.Instant;
 
 /**
@@ -36,7 +37,7 @@ public class SqlLease extends Lease {
         this.leaseId = leaseId;
     }
 
-    public boolean isExpired() {
-        return getLeasedAt() + getLeaseDuration() < Instant.now().toEpochMilli();
+    public boolean isExpired(Clock clock) {
+        return getLeasedAt() + getLeaseDuration() < clock.millis();
     }
 }

--- a/extensions/sql/lease-sql/src/main/java/org/eclipse/dataspaceconnector/sql/lease/SqlLeaseContext.java
+++ b/extensions/sql/lease-sql/src/main/java/org/eclipse/dataspaceconnector/sql/lease/SqlLeaseContext.java
@@ -22,8 +22,8 @@ import org.jetbrains.annotations.Nullable;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Clock;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -40,13 +40,15 @@ public class SqlLeaseContext implements LeaseContext {
     private final LeaseStatements statements;
     private final String leaseHolder;
     private final Connection connection;
+    private final Clock clock;
     private final Duration leaseDuration;
 
 
-    SqlLeaseContext(TransactionContext trxContext, LeaseStatements statements, String leaseHolder, Duration leaseDuration, Connection connection) {
+    SqlLeaseContext(TransactionContext trxContext, LeaseStatements statements, String leaseHolder, Clock clock, Duration leaseDuration, Connection connection) {
         this.trxContext = trxContext;
         this.statements = statements;
         this.leaseHolder = leaseHolder;
+        this.clock = clock;
         this.leaseDuration = leaseDuration;
         this.connection = connection;
     }
@@ -71,7 +73,7 @@ public class SqlLeaseContext implements LeaseContext {
     @Override
     public void acquireLease(String entityId) {
         trxContext.execute(() -> {
-            var now = Instant.now().toEpochMilli();
+            var now = clock.millis();
 
             var lease = getLease(entityId);
 

--- a/extensions/sql/lease-sql/src/main/java/org/eclipse/dataspaceconnector/sql/lease/SqlLeaseContext.java
+++ b/extensions/sql/lease-sql/src/main/java/org/eclipse/dataspaceconnector/sql/lease/SqlLeaseContext.java
@@ -77,7 +77,7 @@ public class SqlLeaseContext implements LeaseContext {
 
             var lease = getLease(entityId);
 
-            if (lease != null && !lease.isExpired()) {
+            if (lease != null && !lease.isExpired(clock)) {
                 throw new IllegalStateException("Entity is currently leased!");
             }
 

--- a/extensions/sql/lease-sql/src/main/java/org/eclipse/dataspaceconnector/sql/lease/SqlLeaseContextBuilder.java
+++ b/extensions/sql/lease-sql/src/main/java/org/eclipse/dataspaceconnector/sql/lease/SqlLeaseContextBuilder.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.sql.lease;
 import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 
 import java.sql.Connection;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.Objects;
 
@@ -41,20 +42,22 @@ import java.util.Objects;
 public class SqlLeaseContextBuilder {
     private final TransactionContext trxContext;
     private final LeaseStatements statements;
+    private final Clock clock;
     private String leaseHolder;
     private Duration leaseDuration;
 
-    private SqlLeaseContextBuilder(TransactionContext trxContext, LeaseStatements statements, String leaseHolder) {
+    private SqlLeaseContextBuilder(TransactionContext trxContext, LeaseStatements statements, String leaseHolder, Clock clock) {
         this.trxContext = trxContext;
         this.statements = statements;
         this.leaseHolder = leaseHolder;
+        this.clock = clock;
     }
 
-    public static SqlLeaseContextBuilder with(TransactionContext trxContext, String leaseHolder, LeaseStatements statements) {
+    public static SqlLeaseContextBuilder with(TransactionContext trxContext, String leaseHolder, LeaseStatements statements, Clock clock) {
         Objects.requireNonNull(trxContext, "trxContext");
         Objects.requireNonNull(leaseHolder, "leaseHolder");
         Objects.requireNonNull(statements, "statements");
-        return new SqlLeaseContextBuilder(trxContext, statements, leaseHolder);
+        return new SqlLeaseContextBuilder(trxContext, statements, leaseHolder, clock);
     }
 
     /**
@@ -79,6 +82,6 @@ public class SqlLeaseContextBuilder {
      */
     public SqlLeaseContext withConnection(Connection connection) {
         Objects.requireNonNull(connection, "connection");
-        return new SqlLeaseContext(trxContext, statements, leaseHolder, leaseDuration, connection);
+        return new SqlLeaseContext(trxContext, statements, leaseHolder, clock, leaseDuration, connection);
     }
 }

--- a/extensions/sql/lease-sql/src/testFixtures/java/org/eclipse/dataspaceconnector/sql/lease/LeaseUtil.java
+++ b/extensions/sql/lease-sql/src/testFixtures/java/org/eclipse/dataspaceconnector/sql/lease/LeaseUtil.java
@@ -18,6 +18,7 @@ import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.function.Supplier;
 
@@ -30,9 +31,9 @@ public class LeaseUtil {
     private final SqlLeaseContextBuilder leaseContextBuilder;
     private final Supplier<Connection> connectionSupplier;
 
-    public LeaseUtil(TransactionContext context, Supplier<Connection> connectionSupplier, LeaseStatements statements) {
+    public LeaseUtil(TransactionContext context, Supplier<Connection> connectionSupplier, LeaseStatements statements, Clock clock) {
         this.connectionSupplier = connectionSupplier;
-        leaseContextBuilder = SqlLeaseContextBuilder.with(context, "test", statements);
+        leaseContextBuilder = SqlLeaseContextBuilder.with(context, "test", statements, clock);
     }
 
     public void leaseEntity(String tpId, String leaseHolder) {

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/SqlTransferProcessStoreExtension.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/SqlTransferProcessStoreExtension.java
@@ -26,6 +26,8 @@ import org.eclipse.dataspaceconnector.sql.transferprocess.store.PostgresStatemen
 import org.eclipse.dataspaceconnector.sql.transferprocess.store.SqlTransferProcessStore;
 import org.eclipse.dataspaceconnector.sql.transferprocess.store.TransferProcessStoreStatements;
 
+import java.time.Clock;
+
 @Provides(TransferProcessStore.class)
 public class SqlTransferProcessStoreExtension implements ServiceExtension {
 
@@ -37,13 +39,15 @@ public class SqlTransferProcessStoreExtension implements ServiceExtension {
     private DataSourceRegistry dataSourceRegistry;
     @Inject
     private TransactionContext trxContext;
+    @Inject
+    private Clock clock;
 
     @Inject(required = false)
     private TransferProcessStoreStatements statements;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var store = new SqlTransferProcessStore(dataSourceRegistry, getDataSourceName(context), trxContext, context.getTypeManager().getMapper(), getStatementImpl(), context.getConnectorId());
+        var store = new SqlTransferProcessStore(dataSourceRegistry, getDataSourceName(context), trxContext, context.getTypeManager().getMapper(), getStatementImpl(), context.getConnectorId(), clock);
         context.registerService(TransferProcessStore.class, store);
     }
 

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/SqlTransferProcessStoreExtension.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/SqlTransferProcessStoreExtension.java
@@ -47,7 +47,7 @@ public class SqlTransferProcessStoreExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var store = new SqlTransferProcessStore(dataSourceRegistry, getDataSourceName(context), trxContext, context.getTypeManager().getMapper(), getStatementImpl(), context.getConnectorId(), clock);
+        var store = new SqlTransferProcessStore(dataSourceRegistry, getDataSourceName(context), trxContext, context.getTypeManager().getMapper(), getStatementImpl(), context.getConnectorId(), clock, clock1);
         context.registerService(TransferProcessStore.class, store);
     }
 

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/SqlTransferProcessStoreExtension.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/SqlTransferProcessStoreExtension.java
@@ -47,7 +47,7 @@ public class SqlTransferProcessStoreExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var store = new SqlTransferProcessStore(dataSourceRegistry, getDataSourceName(context), trxContext, context.getTypeManager().getMapper(), getStatementImpl(), context.getConnectorId(), clock, clock1);
+        var store = new SqlTransferProcessStore(dataSourceRegistry, getDataSourceName(context), trxContext, context.getTypeManager().getMapper(), getStatementImpl(), context.getConnectorId(), clock);
         context.registerService(TransferProcessStore.class, store);
     }
 

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -37,7 +37,6 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Clock;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -54,22 +53,23 @@ public class SqlTransferProcessStore implements TransferProcessStore {
     private final TransferProcessStoreStatements statements;
     private final String leaseHolderName;
     private final SqlLeaseContextBuilder leaseContext;
+    private final Clock clock;
 
     public SqlTransferProcessStore(DataSourceRegistry dataSourceRegistry, String datasourceName, TransactionContext transactionContext, ObjectMapper objectMapper, TransferProcessStoreStatements statements, String leaseHolderName, Clock clock) {
-
         this.dataSourceRegistry = dataSourceRegistry;
         this.datasourceName = datasourceName;
         this.transactionContext = transactionContext;
         this.objectMapper = objectMapper;
         this.statements = statements;
         this.leaseHolderName = leaseHolderName;
+        this.clock = clock;
         leaseContext = SqlLeaseContextBuilder.with(transactionContext, leaseHolderName, statements, clock);
     }
 
     @Override
     public @NotNull List<TransferProcess> nextForState(int state, int max) {
         var list = new ArrayList<TransferProcess>();
-        var now = Instant.now().toEpochMilli();
+        var now = clock.millis();
         transactionContext.execute(() -> {
             try (var conn = getConnection()) {
                 var stmt = statements.getNextForStateTemplate();

--- a/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/sql/transfer-process-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -36,6 +36,7 @@ import org.jetbrains.annotations.Nullable;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,7 +55,7 @@ public class SqlTransferProcessStore implements TransferProcessStore {
     private final String leaseHolderName;
     private final SqlLeaseContextBuilder leaseContext;
 
-    public SqlTransferProcessStore(DataSourceRegistry dataSourceRegistry, String datasourceName, TransactionContext transactionContext, ObjectMapper objectMapper, TransferProcessStoreStatements statements, String leaseHolderName) {
+    public SqlTransferProcessStore(DataSourceRegistry dataSourceRegistry, String datasourceName, TransactionContext transactionContext, ObjectMapper objectMapper, TransferProcessStoreStatements statements, String leaseHolderName, Clock clock) {
 
         this.dataSourceRegistry = dataSourceRegistry;
         this.datasourceName = datasourceName;
@@ -62,7 +63,7 @@ public class SqlTransferProcessStore implements TransferProcessStore {
         this.objectMapper = objectMapper;
         this.statements = statements;
         this.leaseHolderName = leaseHolderName;
-        leaseContext = SqlLeaseContextBuilder.with(transactionContext, leaseHolderName, statements);
+        leaseContext = SqlLeaseContextBuilder.with(transactionContext, leaseHolderName, statements, clock);
     }
 
     @Override

--- a/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStoreTest.java
+++ b/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStoreTest.java
@@ -78,7 +78,7 @@ class SqlTransferProcessStoreTest {
         when(datasourceMock.getConnection()).thenReturn(connection);
         when(dataSourceRegistry.resolve(DATASOURCE_NAME)).thenReturn(datasourceMock);
         var statements = new PostgresStatements();
-        store = new SqlTransferProcessStore(dataSourceRegistry, DATASOURCE_NAME, transactionContext, new ObjectMapper(), statements, CONNECTOR_NAME, Clock.systemUTC());
+        store = new SqlTransferProcessStore(dataSourceRegistry, DATASOURCE_NAME, transactionContext, new ObjectMapper(), statements, CONNECTOR_NAME, Clock.systemUTC(), clock1);
 
         var schema = Files.readString(Paths.get("./docs/schema.sql"));
         transactionContext.execute(() -> SqlQueryExecutor.executeQuery(connection, schema));

--- a/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStoreTest.java
+++ b/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStoreTest.java
@@ -78,7 +78,7 @@ class SqlTransferProcessStoreTest {
         when(datasourceMock.getConnection()).thenReturn(connection);
         when(dataSourceRegistry.resolve(DATASOURCE_NAME)).thenReturn(datasourceMock);
         var statements = new PostgresStatements();
-        store = new SqlTransferProcessStore(dataSourceRegistry, DATASOURCE_NAME, transactionContext, new ObjectMapper(), statements, CONNECTOR_NAME, Clock.systemUTC(), clock1);
+        store = new SqlTransferProcessStore(dataSourceRegistry, DATASOURCE_NAME, transactionContext, new ObjectMapper(), statements, CONNECTOR_NAME, Clock.systemUTC());
 
         var schema = Files.readString(Paths.get("./docs/schema.sql"));
         transactionContext.execute(() -> SqlQueryExecutor.executeQuery(connection, schema));

--- a/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStoreTest.java
+++ b/extensions/sql/transfer-process-store-sql/src/test/java/org/eclipse/dataspaceconnector/sql/transferprocess/store/SqlTransferProcessStoreTest.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -77,12 +78,12 @@ class SqlTransferProcessStoreTest {
         when(datasourceMock.getConnection()).thenReturn(connection);
         when(dataSourceRegistry.resolve(DATASOURCE_NAME)).thenReturn(datasourceMock);
         var statements = new PostgresStatements();
-        store = new SqlTransferProcessStore(dataSourceRegistry, DATASOURCE_NAME, transactionContext, new ObjectMapper(), statements, CONNECTOR_NAME);
+        store = new SqlTransferProcessStore(dataSourceRegistry, DATASOURCE_NAME, transactionContext, new ObjectMapper(), statements, CONNECTOR_NAME, Clock.systemUTC());
 
         var schema = Files.readString(Paths.get("./docs/schema.sql"));
         transactionContext.execute(() -> SqlQueryExecutor.executeQuery(connection, schema));
 
-        leaseUtil = new LeaseUtil(transactionContext, this::getConnection, statements);
+        leaseUtil = new LeaseUtil(transactionContext, this::getConnection, statements, Clock.systemUTC());
 
     }
 

--- a/samples/04.2-modify-transferprocess/simulator/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/TransferSimulationExtension.java
+++ b/samples/04.2-modify-transferprocess/simulator/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/TransferSimulationExtension.java
@@ -51,7 +51,7 @@ public class TransferSimulationExtension implements ServiceExtension {
                                 .id("tp-sample-04.2")
                                 .dataRequest(getRequest())
                                 .state(TransferProcessStates.IN_PROGRESS.code())
-                                .stateTimestamp(System.currentTimeMillis() - ALMOST_TEN_MINUTES)
+                                .stateTimestamp(context.getClock().millis() - ALMOST_TEN_MINUTES)
                                 .build();
                         tp.addProvisionedResource(createDummyResource());
 

--- a/samples/04.2-modify-transferprocess/watchdog/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/CheckTimeoutCommandHandler.java
+++ b/samples/04.2-modify-transferprocess/watchdog/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/CheckTimeoutCommandHandler.java
@@ -18,18 +18,20 @@ import org.eclipse.dataspaceconnector.spi.command.CommandHandler;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 
+import java.time.Clock;
 import java.time.Duration;
 
 import static java.lang.String.format;
-import static java.time.Instant.now;
 import static java.time.Instant.ofEpochMilli;
 
 public class CheckTimeoutCommandHandler implements CommandHandler<CheckTransferProcessTimeoutCommand> {
     private final TransferProcessStore store;
     private final Monitor monitor;
+    private final Clock clock;
 
-    public CheckTimeoutCommandHandler(TransferProcessStore store, Monitor monitor) {
+    public CheckTimeoutCommandHandler(TransferProcessStore store, Clock clock, Monitor monitor) {
         this.store = store;
+        this.clock = clock;
         this.monitor = monitor;
     }
 
@@ -52,7 +54,7 @@ public class CheckTimeoutCommandHandler implements CommandHandler<CheckTransferP
     }
 
     private boolean isExpired(long stateTimestamp, Duration maxAge) {
-        return ofEpochMilli(stateTimestamp).isBefore(now().minus(maxAge));
+        return ofEpochMilli(stateTimestamp).isBefore(clock.instant().minus(maxAge));
     }
 
 }

--- a/samples/04.2-modify-transferprocess/watchdog/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/WatchdogExtension.java
+++ b/samples/04.2-modify-transferprocess/watchdog/src/main/java/org/eclipse/dataspaceconnector/samples/sample042/WatchdogExtension.java
@@ -35,7 +35,7 @@ public class WatchdogExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        commandHandlerRegistry.register(new CheckTimeoutCommandHandler(store, context.getMonitor()));
+        commandHandlerRegistry.register(new CheckTimeoutCommandHandler(store, context.getClock(), context.getMonitor()));
         wd = new Watchdog(manager, context.getMonitor());
     }
 

--- a/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ServiceExtensionContext.java
+++ b/spi/core-spi/src/main/java/org/eclipse/dataspaceconnector/spi/system/ServiceExtensionContext.java
@@ -19,6 +19,8 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.telemetry.Telemetry;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 
+import java.time.Clock;
+
 /**
  * Context provided to extensions when they are initialized.
  */
@@ -33,17 +35,30 @@ public interface ServiceExtensionContext extends SettingResolver {
     /**
      * Returns the system monitor.
      */
-    Monitor getMonitor();
+    default Monitor getMonitor() {
+        return getService(Monitor.class);
+    }
 
     /**
      * Returns the system telemetry object.
      */
-    Telemetry getTelemetry();
+    default Telemetry getTelemetry() {
+        return getService(Telemetry.class);
+    }
 
     /**
      * Returns the type manager.
      */
-    TypeManager getTypeManager();
+    default TypeManager getTypeManager() {
+        return getService(TypeManager.class);
+    }
+
+    /**
+     * Returns the {@link Clock} to retrieve the current time, which can be mocked in unit tests.
+     */
+    default Clock getClock() {
+        return getService(Clock.class);
+    }
 
     /**
      * Returns true if the service type is registered.

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
@@ -408,7 +408,7 @@ public class TransferProcess implements TraceCarrier {
         private final TransferProcess process;
 
         private Builder(TransferProcess process) {
-            this.process = process.copy();
+            this.process = process;
         }
 
         @JsonCreator

--- a/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
+++ b/spi/transfer-spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
@@ -26,6 +26,7 @@ import org.eclipse.dataspaceconnector.spi.types.domain.DataAddress;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -111,6 +112,7 @@ public class TransferProcess implements TraceCarrier {
     private ResourceManifest resourceManifest;
     private ProvisionedResourceSet provisionedResourceSet;
     private List<DeprovisionedResource> deprovisionedResources = new ArrayList<>();
+    private Clock clock = Clock.systemUTC();
 
     private TransferProcess() {
     }
@@ -326,13 +328,6 @@ public class TransferProcess implements TraceCarrier {
         updateStateTimestamp();
     }
 
-
-    public void rollbackState(TransferProcessStates state) {
-        this.state = state.code();
-        stateCount = 1;
-        updateStateTimestamp();
-    }
-
     public TransferProcess copy() {
         return Builder.newInstance()
                 .id(id)
@@ -347,6 +342,7 @@ public class TransferProcess implements TraceCarrier {
                 .type(type)
                 .createdTimestamp(createdTimestamp)
                 .errorDetail(errorDetail)
+                .clock(clock)
                 .build();
     }
 
@@ -380,8 +376,13 @@ public class TransferProcess implements TraceCarrier {
                 '}';
     }
 
+    /**
+     * Sets the state timestamp to the clock time.
+     *
+     * @see Builder#clock(Clock)
+     */
     public void updateStateTimestamp() {
-        stateTimestamp = Instant.now().toEpochMilli();
+        stateTimestamp = clock.millis();
     }
 
     private void transition(TransferProcessStates end, TransferProcessStates... starts) {
@@ -407,7 +408,7 @@ public class TransferProcess implements TraceCarrier {
         private final TransferProcess process;
 
         private Builder(TransferProcess process) {
-            this.process = process;
+            this.process = process.copy();
         }
 
         @JsonCreator
@@ -422,6 +423,11 @@ public class TransferProcess implements TraceCarrier {
 
         public Builder type(Type type) {
             process.type = type;
+            return this;
+        }
+
+        public Builder clock(Clock clock) {
+            process.clock = clock;
             return this;
         }
 
@@ -482,8 +488,9 @@ public class TransferProcess implements TraceCarrier {
 
         public TransferProcess build() {
             Objects.requireNonNull(process.id, "id");
+            Objects.requireNonNull(process.clock, "clock");
             if (process.state == UNSAVED.code() && process.stateTimestamp == 0) {
-                process.stateTimestamp = Instant.now().toEpochMilli();
+                process.stateTimestamp = process.clock.millis();
             }
             if (process.resourceManifest != null) {
                 process.resourceManifest.setTransferProcessId(process.id);

--- a/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcessTest.java
+++ b/spi/transfer-spi/src/test/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcessTest.java
@@ -29,7 +29,6 @@ import java.util.UUID;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessStates.INITIAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -121,18 +120,6 @@ class TransferProcessTest {
         process.transitionDeprovisioning();
         process.transitionDeprovisioned();
         process.transitionEnded();
-    }
-
-    @Test
-    void verifyTransitionRollback() {
-        var process = TransferProcess.Builder.newInstance().id(UUID.randomUUID().toString()).build();
-        process.transitionInitial();
-        process.transitionProvisioning(ResourceManifest.Builder.newInstance().build());
-
-        process.rollbackState(INITIAL);
-
-        assertEquals(INITIAL.code(), process.getState());
-        assertEquals(1, process.getStateCount());
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Use a mockable `Clock` to get the time.

Removes calls to `Instant.now()`, `new Date()`, `System.currentTimeMillis()` from production code.

## Why it does that

- Make access to system time consistent in code base.
- Make time mockable for testing.
- Make tests simple and reliable (avoid approximate time comparisons, etc.).

## Further notes

- Moved convenience method implementations from `DefaultServiceExtensionContext` to the interface
- Changed `DataPlaneInstance` contract to return null instead of 0 for empty `lastActive` time.
- `nbf`: in discussion with Ben
- Removed `rollbackState` method in ContractNegotiation and TransferProcess, as it's unused and violates state machine contract.
- Consistently inject services in `ContractServiceExtension`

## Linked Issue(s)

#284

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
