### PR TITLE
Feature/1512/294 cosmosdb missing field behavior

### DIFF
--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -452,7 +452,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
         var query = QuerySpec.Builder.newInstance().sortField("xyz").sortOrder(SortOrder.ASC).build();
         var negotiations = store.queryNegotiations(query);
 
-        assertThat(negotiations).isEmpty();
+        assertThat(negotiations).hasSize(10);
     }
 
     @Test

--- a/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/contract/negotiation/store/CosmosContractNegotiationStoreIntegrationTest.java
@@ -544,7 +544,7 @@ class CosmosContractNegotiationStoreIntegrationTest {
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
         var agreements = store.queryAgreements(query);
 
-        assertThat(agreements).isEmpty();
+        assertThat(agreements).hasSize(10);
     }
 
     @Test

--- a/extensions/azure/cosmos/policy-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/cosmos/policy/store/CosmosPolicyDefinitionStoreIntegrationTest.java
+++ b/extensions/azure/cosmos/policy-store-cosmos/src/test/java/org/eclipse/dataspaceconnector/cosmos/policy/store/CosmosPolicyDefinitionStoreIntegrationTest.java
@@ -293,7 +293,7 @@ public class CosmosPolicyDefinitionStoreIntegrationTest {
         store.save(modifiedPolicy);
 
         // re-read
-        var all = store.findAll(QuerySpec.Builder.newInstance().filter("permissions[0].target=test-asset-id").build()).collect(Collectors.toList());
+        var all = store.findAll(QuerySpec.Builder.newInstance().filter("policy.permissions[0].target=test-asset-id").build()).collect(Collectors.toList());
         assertThat(all).hasSize(1).containsExactly(modifiedPolicy);
 
     }


### PR DESCRIPTION
## What this PR changes/adds

Fix failing Cosmos DB integration test `CosmosContractNegotiationStoreIntegrationTest`.

## Why it does that

Cosmos DB behavior recently changed as [documented](https://docs.microsoft.com/en-us/azure/cosmos-db/sql/sql-query-order-by): *Queries with ORDER BY will return all items, including items where the property in the ORDER BY clause isn't defined.*

## Further notes

Also fixed logic for failing org.eclipse.dataspaceconnector.cosmos.policy.store.CosmosPolicyDefinitionStoreIntegrationTest#verify_readWriteFindAll

## Linked Issue(s)

#294 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
