### PR TITLE
Feature/1522/311 did testability

### DIFF
--- a/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/WebDidExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/WebDidExtension.java
@@ -20,7 +20,6 @@ import okhttp3.dnsoverhttps.DnsOverHttps;
 import org.eclipse.dataspaceconnector.common.string.StringUtils;
 import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.dataspaceconnector.iam.did.web.resolution.WebDidResolver;
-import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -28,19 +27,10 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import static java.util.Objects.requireNonNull;
 import static org.eclipse.dataspaceconnector.iam.did.web.ConfigurationKeys.DNS_OVER_HTTPS;
 
-
 /**
  * Initializes support for resolving Web DIDs.
  */
 public class WebDidExtension implements ServiceExtension {
-    /**
-     * Set to {@code false} to create DID URLs with {@code http} instead of {@code https} scheme.
-     * Defaults to {@code true}.
-     * <p>
-     * This setting can be used by EDC downstream projects, e.g. for testing with docker compose
-     */
-    @EdcSetting
-    private static final String USE_HTTPS_SCHEME = "edc.iam.did.web.use.https";
 
     @Inject
     private DidResolverRegistry resolverRegistry;
@@ -54,11 +44,10 @@ public class WebDidExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         var mapper = context.getTypeManager().getMapper();
         var monitor = context.getMonitor();
-        var useHttpsScheme = context.getSetting(USE_HTTPS_SCHEME, true);
 
         OkHttpClient httpClient = getOkHttpClient(context);
 
-        var resolver = new WebDidResolver(httpClient, useHttpsScheme, mapper, monitor);
+        var resolver = new WebDidResolver(httpClient, mapper, monitor);
 
         resolverRegistry.register(resolver);
     }

--- a/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/WebDidExtension.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/WebDidExtension.java
@@ -20,6 +20,7 @@ import okhttp3.dnsoverhttps.DnsOverHttps;
 import org.eclipse.dataspaceconnector.common.string.StringUtils;
 import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.dataspaceconnector.iam.did.web.resolution.WebDidResolver;
+import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
@@ -27,10 +28,19 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import static java.util.Objects.requireNonNull;
 import static org.eclipse.dataspaceconnector.iam.did.web.ConfigurationKeys.DNS_OVER_HTTPS;
 
+
 /**
  * Initializes support for resolving Web DIDs.
  */
 public class WebDidExtension implements ServiceExtension {
+    /**
+     * Set to {@code false} to create DID URLs with {@code http} instead of {@code https} scheme.
+     * Defaults to {@code true}.
+     * <p>
+     * This setting can be used by EDC downstream projects, e.g. for testing with docker compose
+     */
+    @EdcSetting
+    private static final String USE_HTTPS_SCHEME = "edc.iam.did.web.use.https";
 
     @Inject
     private DidResolverRegistry resolverRegistry;
@@ -44,10 +54,11 @@ public class WebDidExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         var mapper = context.getTypeManager().getMapper();
         var monitor = context.getMonitor();
+        var useHttpsScheme = context.getSetting(USE_HTTPS_SCHEME, true);
 
         OkHttpClient httpClient = getOkHttpClient(context);
 
-        var resolver = new WebDidResolver(httpClient, mapper, monitor);
+        var resolver = new WebDidResolver(httpClient, useHttpsScheme, mapper, monitor);
 
         resolverRegistry.register(resolver);
     }

--- a/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/DidFunctions.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/DidFunctions.java
@@ -18,50 +18,35 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Objects;
 
 /**
  * Provides methods for manipulating Web DIDs.
  */
-@SuppressWarnings("HttpUrlsUsage")
-class DidFunctions {
+public class DidFunctions {
     private static final String DID_SCHEME = "did";
     private static final String DID_METHOD_PREFIX = "web:";
-    private static final String HTTP_PREFIX = "http://";
     private static final String HTTPS_PREFIX = "https://";
     private static final String DID_DOCUMENT = "did.json";
     private static final String WELL_KNOWN = "/.well-known/";
 
     /**
-     * Converts a Web DID to a URL according to the Web DID specification.
-     * <p>
-     * To follow the specification, the {@code useHttpsScheme} parameter must be set to {@code true}.
-     * The {@code false} value can be used for integration testing.
-     *
-     * @param did            Decentralized identifier in {@code "did:web:..."} format
-     * @param useHttpsScheme whether to create DID URLs with {@code https}, otherwise uses {@code https} scheme
-     * @return DID Document URL corresponding to {@code did}
-     * @throws IllegalArgumentException if {@code did} has invalid format
-     * @throws NullPointerException     if {@code did} is {@code null}
-     * @see <a href="https://w3c-ccg.github.io/did-method-web/#read-resolve"did:web Method Specification: Read (Resolve)</a>
+     * Converts a DID URN to a URL according to the Web DID specification, .cf https://w3c-ccg.github.io/did-method-web/#read-resolve.
      */
-    static String resolveDidDocumentUrl(String did, boolean useHttpsScheme) throws IllegalArgumentException {
-        Objects.requireNonNull(did, "did");
+    public static String keyToUrl(String didKey) throws IllegalArgumentException {
         try {
-            var uri = new URI(did);
+            var uri = new URI(didKey);
             if (!DID_SCHEME.equalsIgnoreCase(uri.getScheme())) {
                 throw new IllegalArgumentException("Invalid DID scheme: " + uri.getScheme());
             }
 
             var part = uri.getSchemeSpecificPart();
             if (!part.startsWith(DID_METHOD_PREFIX)) {
-                throw new IllegalArgumentException("Invalid DID format, the URN must specify the 'web' DID Method: " + did);
+                throw new IllegalArgumentException("Invalid DID format, the URN must specify the 'web' DID Method: " + didKey);
             } else if (part.endsWith(":")) {
-                throw new IllegalArgumentException("Invalid DID format, the URN must not end with ':': " + did);
+                throw new IllegalArgumentException("Invalid DID format, the URN must not end with ':': " + didKey);
             }
 
-            var prefix = useHttpsScheme ? HTTPS_PREFIX : HTTP_PREFIX;
-            var identifier = new URL(prefix + part.substring(DID_METHOD_PREFIX.length()).replace(':', '/'));
+            var identifier = new URL(HTTPS_PREFIX + part.substring(DID_METHOD_PREFIX.length()).replace(':', '/'));
             if (identifier.getPath().length() == 0) {
                 return identifier + WELL_KNOWN + DID_DOCUMENT;
             } else {

--- a/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/DidFunctions.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/DidFunctions.java
@@ -18,35 +18,50 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Objects;
 
 /**
  * Provides methods for manipulating Web DIDs.
  */
-public class DidFunctions {
+@SuppressWarnings("HttpUrlsUsage")
+class DidFunctions {
     private static final String DID_SCHEME = "did";
     private static final String DID_METHOD_PREFIX = "web:";
+    private static final String HTTP_PREFIX = "http://";
     private static final String HTTPS_PREFIX = "https://";
     private static final String DID_DOCUMENT = "did.json";
     private static final String WELL_KNOWN = "/.well-known/";
 
     /**
-     * Converts a DID URN to a URL according to the Web DID specification, .cf https://w3c-ccg.github.io/did-method-web/#read-resolve.
+     * Converts a Web DID to a URL according to the Web DID specification.
+     * <p>
+     * To follow the specification, the {@code useHttpsScheme} parameter must be set to {@code true}.
+     * The {@code false} value can be used for integration testing.
+     *
+     * @param did            Decentralized identifier in {@code "did:web:..."} format
+     * @param useHttpsScheme whether to create DID URLs with {@code https}, otherwise uses {@code https} scheme
+     * @return DID Document URL corresponding to {@code did}
+     * @throws IllegalArgumentException if {@code did} has invalid format
+     * @throws NullPointerException     if {@code did} is {@code null}
+     * @see <a href="https://w3c-ccg.github.io/did-method-web/#read-resolve"did:web Method Specification: Read (Resolve)</a>
      */
-    public static String keyToUrl(String didKey) throws IllegalArgumentException {
+    static String resolveDidDocumentUrl(String did, boolean useHttpsScheme) throws IllegalArgumentException {
+        Objects.requireNonNull(did, "did");
         try {
-            var uri = new URI(didKey);
+            var uri = new URI(did);
             if (!DID_SCHEME.equalsIgnoreCase(uri.getScheme())) {
                 throw new IllegalArgumentException("Invalid DID scheme: " + uri.getScheme());
             }
 
             var part = uri.getSchemeSpecificPart();
             if (!part.startsWith(DID_METHOD_PREFIX)) {
-                throw new IllegalArgumentException("Invalid DID format, the URN must specify the 'web' DID Method: " + didKey);
+                throw new IllegalArgumentException("Invalid DID format, the URN must specify the 'web' DID Method: " + did);
             } else if (part.endsWith(":")) {
-                throw new IllegalArgumentException("Invalid DID format, the URN must not end with ':': " + didKey);
+                throw new IllegalArgumentException("Invalid DID format, the URN must not end with ':': " + did);
             }
 
-            var identifier = new URL(HTTPS_PREFIX + part.substring(DID_METHOD_PREFIX.length()).replace(':', '/'));
+            var prefix = useHttpsScheme ? HTTPS_PREFIX : HTTP_PREFIX;
+            var identifier = new URL(prefix + part.substring(DID_METHOD_PREFIX.length()).replace(':', '/'));
             if (identifier.getPath().length() == 0) {
                 return identifier + WELL_KNOWN + DID_DOCUMENT;
             } else {

--- a/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/WebDidResolver.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/WebDidResolver.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.IOException;
 
 import static java.lang.String.format;
-import static org.eclipse.dataspaceconnector.iam.did.web.resolution.DidFunctions.keyToUrl;
+import static org.eclipse.dataspaceconnector.iam.did.web.resolution.DidFunctions.resolveDidDocumentUrl;
 
 /**
  * Resolves a Web DID according to the Web DID specification (https://w3c-ccg.github.io/did-method-web).
@@ -37,12 +37,14 @@ public class WebDidResolver implements DidResolver {
     private final OkHttpClient httpClient;
     private final ObjectMapper mapper;
     private final Monitor monitor;
+    private final boolean useHttpsScheme;
 
     /**
      * Creates a resolver that executes standard DNS lookups.
      */
-    public WebDidResolver(OkHttpClient httpClient, ObjectMapper mapper, Monitor monitor) {
+    public WebDidResolver(OkHttpClient httpClient, boolean useHttpsScheme, ObjectMapper mapper, Monitor monitor) {
         this.httpClient = httpClient;
+        this.useHttpsScheme = useHttpsScheme;
         this.mapper = mapper;
         this.monitor = monitor;
     }
@@ -56,7 +58,7 @@ public class WebDidResolver implements DidResolver {
     @NotNull
     public Result<DidDocument> resolve(String didKey) {
         try {
-            var request = new Request.Builder().url(keyToUrl(didKey)).get().build();
+            var request = new Request.Builder().url(resolveDidDocumentUrl(didKey, useHttpsScheme)).get().build();
 
             try (var response = httpClient.newCall(request).execute()) {
                 if (response.code() != 200) {

--- a/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/WebDidResolver.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/WebDidResolver.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.IOException;
 
 import static java.lang.String.format;
-import static org.eclipse.dataspaceconnector.iam.did.web.resolution.DidFunctions.resolveDidDocumentUrl;
+import static org.eclipse.dataspaceconnector.iam.did.web.resolution.DidFunctions.keyToUrl;
 
 /**
  * Resolves a Web DID according to the Web DID specification (https://w3c-ccg.github.io/did-method-web).
@@ -37,14 +37,12 @@ public class WebDidResolver implements DidResolver {
     private final OkHttpClient httpClient;
     private final ObjectMapper mapper;
     private final Monitor monitor;
-    private final boolean useHttpsScheme;
 
     /**
      * Creates a resolver that executes standard DNS lookups.
      */
-    public WebDidResolver(OkHttpClient httpClient, boolean useHttpsScheme, ObjectMapper mapper, Monitor monitor) {
+    public WebDidResolver(OkHttpClient httpClient, ObjectMapper mapper, Monitor monitor) {
         this.httpClient = httpClient;
-        this.useHttpsScheme = useHttpsScheme;
         this.mapper = mapper;
         this.monitor = monitor;
     }
@@ -58,7 +56,7 @@ public class WebDidResolver implements DidResolver {
     @NotNull
     public Result<DidDocument> resolve(String didKey) {
         try {
-            var request = new Request.Builder().url(resolveDidDocumentUrl(didKey, useHttpsScheme)).get().build();
+            var request = new Request.Builder().url(keyToUrl(didKey)).get().build();
 
             try (var response = httpClient.newCall(request).execute()) {
                 if (response.code() != 200) {

--- a/extensions/iam/decentralized-identity/identity-did-web/src/test/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/DidFunctionsTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/test/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/DidFunctionsTest.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.dataspaceconnector.iam.did.web.resolution;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.eclipse.dataspaceconnector.iam.did.web.resolution.DidFunctions.resolveDidDocumentUrl;
 
@@ -29,10 +29,10 @@ class DidFunctionsTest {
      * Verifies Web DID URN mappings.
      */
     @Test
-    void verifyConvertToUrl() throws Exception {
-        Assertions.assertThat(resolveDidDocumentUrl("did:web:w3c-ccg.github.io", true)).isEqualTo("https://w3c-ccg.github.io/.well-known/did.json");
-        Assertions.assertThat(resolveDidDocumentUrl("did:web:w3c-ccg.github.io", false)).isEqualTo("http://w3c-ccg.github.io/.well-known/did.json");
-        Assertions.assertThat(resolveDidDocumentUrl("did:web:w3c-ccg.github.io:user:alice", true)).isEqualTo("https://w3c-ccg.github.io/user/alice/did.json");
+    void verifyResolveDidDocumentUrl() {
+        assertThat(resolveDidDocumentUrl("did:web:w3c-ccg.github.io", true)).isEqualTo("https://w3c-ccg.github.io/.well-known/did.json");
+        assertThat(resolveDidDocumentUrl("did:web:w3c-ccg.github.io", false)).isEqualTo("http://w3c-ccg.github.io/.well-known/did.json");
+        assertThat(resolveDidDocumentUrl("did:web:w3c-ccg.github.io:user:alice", true)).isEqualTo("https://w3c-ccg.github.io/user/alice/did.json");
 
         assertThatIllegalArgumentException().isThrownBy(() -> resolveDidDocumentUrl("did:web:w3c-ccg.github.io:user:alice:", true));
     }

--- a/extensions/iam/decentralized-identity/identity-did-web/src/test/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/DidFunctionsTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/test/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/DidFunctionsTest.java
@@ -18,7 +18,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.eclipse.dataspaceconnector.iam.did.web.resolution.DidFunctions.keyToUrl;
+import static org.eclipse.dataspaceconnector.iam.did.web.resolution.DidFunctions.resolveDidDocumentUrl;
 
 /**
  * Verifies DID functions.
@@ -30,10 +30,11 @@ class DidFunctionsTest {
      */
     @Test
     void verifyConvertToUrl() throws Exception {
-        Assertions.assertThat(keyToUrl("did:web:w3c-ccg.github.io")).isEqualTo("https://w3c-ccg.github.io/.well-known/did.json");
-        Assertions.assertThat(keyToUrl("did:web:w3c-ccg.github.io:user:alice")).isEqualTo("https://w3c-ccg.github.io/user/alice/did.json");
+        Assertions.assertThat(resolveDidDocumentUrl("did:web:w3c-ccg.github.io", true)).isEqualTo("https://w3c-ccg.github.io/.well-known/did.json");
+        Assertions.assertThat(resolveDidDocumentUrl("did:web:w3c-ccg.github.io", false)).isEqualTo("http://w3c-ccg.github.io/.well-known/did.json");
+        Assertions.assertThat(resolveDidDocumentUrl("did:web:w3c-ccg.github.io:user:alice", true)).isEqualTo("https://w3c-ccg.github.io/user/alice/did.json");
 
-        assertThatIllegalArgumentException().isThrownBy(() -> keyToUrl("did:web:w3c-ccg.github.io:user:alice:"));
+        assertThatIllegalArgumentException().isThrownBy(() -> resolveDidDocumentUrl("did:web:w3c-ccg.github.io:user:alice:", true));
     }
 
 

--- a/extensions/iam/decentralized-identity/identity-did-web/src/test/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/DidFunctionsTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/test/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/DidFunctionsTest.java
@@ -18,7 +18,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.eclipse.dataspaceconnector.iam.did.web.resolution.DidFunctions.resolveDidDocumentUrl;
+import static org.eclipse.dataspaceconnector.iam.did.web.resolution.DidFunctions.keyToUrl;
 
 /**
  * Verifies DID functions.
@@ -30,11 +30,10 @@ class DidFunctionsTest {
      */
     @Test
     void verifyConvertToUrl() throws Exception {
-        Assertions.assertThat(resolveDidDocumentUrl("did:web:w3c-ccg.github.io", true)).isEqualTo("https://w3c-ccg.github.io/.well-known/did.json");
-        Assertions.assertThat(resolveDidDocumentUrl("did:web:w3c-ccg.github.io", false)).isEqualTo("http://w3c-ccg.github.io/.well-known/did.json");
-        Assertions.assertThat(resolveDidDocumentUrl("did:web:w3c-ccg.github.io:user:alice", true)).isEqualTo("https://w3c-ccg.github.io/user/alice/did.json");
+        Assertions.assertThat(keyToUrl("did:web:w3c-ccg.github.io")).isEqualTo("https://w3c-ccg.github.io/.well-known/did.json");
+        Assertions.assertThat(keyToUrl("did:web:w3c-ccg.github.io:user:alice")).isEqualTo("https://w3c-ccg.github.io/user/alice/did.json");
 
-        assertThatIllegalArgumentException().isThrownBy(() -> resolveDidDocumentUrl("did:web:w3c-ccg.github.io:user:alice:", true));
+        assertThatIllegalArgumentException().isThrownBy(() -> keyToUrl("did:web:w3c-ccg.github.io:user:alice:"));
     }
 
 

--- a/extensions/iam/decentralized-identity/identity-did-web/src/test/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/WebDidResolverTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/test/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/WebDidResolverTest.java
@@ -77,7 +77,7 @@ class WebDidResolverTest {
         }
         var mapper = new ObjectMapper();
         Monitor monitor = mock(Monitor.class);
-        return new WebDidResolver(builder.build(), true, mapper, monitor);
+        return new WebDidResolver(builder.build(), mapper, monitor);
     }
 
 }

--- a/extensions/iam/decentralized-identity/identity-did-web/src/test/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/WebDidResolverTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-web/src/test/java/org/eclipse/dataspaceconnector/iam/did/web/resolution/WebDidResolverTest.java
@@ -77,7 +77,7 @@ class WebDidResolverTest {
         }
         var mapper = new ObjectMapper();
         Monitor monitor = mock(Monitor.class);
-        return new WebDidResolver(builder.build(), mapper, monitor);
+        return new WebDidResolver(builder.build(), true, mapper, monitor);
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Create an EdcSetting to optionally toggle http:// scheme instead of https:// when resolving DID Document URLs

## Why it does that

When testing a deployment in docker-compose, it's quite a hassle to set up SSL and trust. It would be much more convenient to have an option to change the scheme to http:// for development.

This will be used by EDC extension projects such as https://github.com/eclipse-dataspaceconnector/RegistrationService for CI and local integration testing.

## Further notes

## Linked Issue(s)

#311 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
