### PR TITLE
Changed CredentialsVerifier contract.

### DIFF
--- a/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifier.java
+++ b/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifier.java
@@ -30,7 +30,7 @@ public class DummyCredentialsVerifier implements CredentialsVerifier {
     private final Monitor monitor;
 
     /**
-     * Create a new credentials verifier that uses an Identity Hub
+     * Create a new dummy Credentials verifier.
      *
      * @param monitor a {@link Monitor}
      */
@@ -41,14 +41,7 @@ public class DummyCredentialsVerifier implements CredentialsVerifier {
     @Override
     public Result<Map<String, Object>> verifyCredentials(DidDocument didDocument) {
 
-        var hubBaseUrl = didDocument.getService().stream()
-                .filter(service -> service.getType().equals(DidConstants.HUB_URL))
-                .map(Service::getServiceEndpoint)
-                .findFirst();
-
-        if (hubBaseUrl.isEmpty()) return Result.failure("No IdentityHub URL service found in DidDocument");
-
-        monitor.debug("Starting (dummy) credential verification against hub URL " + hubBaseUrl.get());
+        monitor.debug("Starting (dummy) credential verification.");
 
         return Result.success(Map.of("region", "eu"));
     }

--- a/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifier.java
+++ b/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifier.java
@@ -15,9 +15,7 @@
 package org.eclipse.dataspaceconnector.iam.verifier;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.credentials.CredentialsVerifier;
-import org.eclipse.dataspaceconnector.iam.did.spi.document.DidConstants;
 import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;
-import org.eclipse.dataspaceconnector.iam.did.spi.document.Service;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 

--- a/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifier.java
+++ b/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifier.java
@@ -39,7 +39,7 @@ public class DummyCredentialsVerifier implements CredentialsVerifier {
     }
 
     @Override
-    public Result<Map<String, Object>> getVerifiedClaims(DidDocument didDocument) {
+    public Result<Map<String, Object>> verifyCredentials(DidDocument didDocument) {
 
         var hubBaseUrl = didDocument.getService().stream().filter(service -> service.getType().equals(DidConstants.HUB_URL)).map(Service::getServiceEndpoint).findFirst().orElseThrow();
         monitor.debug("Starting (dummy) credential verification against hub URL " + hubBaseUrl);

--- a/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifier.java
+++ b/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifier.java
@@ -15,7 +15,9 @@
 package org.eclipse.dataspaceconnector.iam.verifier;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.credentials.CredentialsVerifier;
-import org.eclipse.dataspaceconnector.iam.did.spi.key.PublicKeyWrapper;
+import org.eclipse.dataspaceconnector.iam.did.spi.document.DidConstants;
+import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;
+import org.eclipse.dataspaceconnector.iam.did.spi.document.Service;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 
@@ -37,7 +39,9 @@ public class DummyCredentialsVerifier implements CredentialsVerifier {
     }
 
     @Override
-    public Result<Map<String, Object>> verifyCredentials(String hubBaseUrl, PublicKeyWrapper othersPublicKey) {
+    public Result<Map<String, Object>> getVerifiedClaims(DidDocument didDocument) {
+
+        var hubBaseUrl = didDocument.getService().stream().filter(service -> service.getType().equals(DidConstants.HUB_URL)).map(Service::getServiceEndpoint).findFirst().orElseThrow();
         monitor.debug("Starting (dummy) credential verification against hub URL " + hubBaseUrl);
 
         return Result.success(Map.of("region", "eu"));

--- a/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifier.java
+++ b/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifier.java
@@ -41,7 +41,12 @@ public class DummyCredentialsVerifier implements CredentialsVerifier {
     @Override
     public Result<Map<String, Object>> verifyCredentials(DidDocument didDocument) {
 
-        var hubBaseUrl = didDocument.getService().stream().filter(service -> service.getType().equals(DidConstants.HUB_URL)).map(Service::getServiceEndpoint).findFirst().orElseThrow();
+        var hubBaseUrl = didDocument.getService().stream()
+                .filter(service -> service.getType().equals(DidConstants.HUB_URL))
+                .map(Service::getServiceEndpoint)
+                .findFirst()
+                .orElseThrow();
+
         monitor.debug("Starting (dummy) credential verification against hub URL " + hubBaseUrl);
 
         return Result.success(Map.of("region", "eu"));

--- a/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifier.java
+++ b/extensions/iam/decentralized-identity/dummy-credentials-verifier/src/main/java/org/eclipse/dataspaceconnector/iam/verifier/DummyCredentialsVerifier.java
@@ -44,10 +44,11 @@ public class DummyCredentialsVerifier implements CredentialsVerifier {
         var hubBaseUrl = didDocument.getService().stream()
                 .filter(service -> service.getType().equals(DidConstants.HUB_URL))
                 .map(Service::getServiceEndpoint)
-                .findFirst()
-                .orElseThrow();
+                .findFirst();
 
-        monitor.debug("Starting (dummy) credential verification against hub URL " + hubBaseUrl);
+        if (hubBaseUrl.isEmpty()) return Result.failure("No IdentityHub URL service found in DidDocument");
+
+        monitor.debug("Starting (dummy) credential verification against hub URL " + hubBaseUrl.get());
 
         return Result.success(Map.of("region", "eu"));
     }

--- a/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityService.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityService.java
@@ -95,7 +95,7 @@ public class DecentralizedIdentityService implements IdentityService {
             }
 
             monitor.debug("verification successful! Fetching data from IdentityHub");
-            var credentialsResult = credentialsVerifier.getVerifiedClaims(didResult.getContent());
+            var credentialsResult = credentialsVerifier.verifyCredentials(didResult.getContent());
 
             monitor.debug("Building ClaimToken");
             var tokenBuilder = ClaimToken.Builder.newInstance();

--- a/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityService.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/main/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityService.java
@@ -93,9 +93,9 @@ public class DecentralizedIdentityService implements IdentityService {
                 verified.getFailureMessages().forEach(m -> monitor.debug(() -> "Failure in token verification: " + m));
                 return Result.failure("Token could not be verified!");
             }
+
             monitor.debug("verification successful! Fetching data from IdentityHub");
-            String hubUrl = getHubUrl(didResult.getContent());
-            var credentialsResult = credentialsVerifier.verifyCredentials(hubUrl, publicKeyWrapper);
+            var credentialsResult = credentialsVerifier.getVerifiedClaims(didResult.getContent());
 
             monitor.debug("Building ClaimToken");
             var tokenBuilder = ClaimToken.Builder.newInstance();

--- a/extensions/iam/decentralized-identity/identity-did-service/src/test/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceTest.java
+++ b/extensions/iam/decentralized-identity/identity-did-service/src/test/java/org/eclipse/dataspaceconnector/identity/DecentralizedIdentityServiceTest.java
@@ -91,7 +91,7 @@ abstract class DecentralizedIdentityServiceTest {
         var privateKey = new EcPrivateKeyWrapper(keyPair.toECKey());
 
         var didResolver = new TestResolverRegistry(DID_DOCUMENT, keyPair);
-        CredentialsVerifier verifier = (document, url) -> Result.success(Map.of("region", "eu"));
+        CredentialsVerifier verifier = document -> Result.success(Map.of("region", "eu"));
         identityService = new DecentralizedIdentityService(didResolver, verifier, new ConsoleMonitor(), privateKey, didUrl, Clock.systemUTC());
     }
 

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/credentials/CredentialsVerifier.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/credentials/CredentialsVerifier.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.dataspaceconnector.iam.did.spi.credentials;
 
-import org.eclipse.dataspaceconnector.iam.did.spi.key.PublicKeyWrapper;
+import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 
 import java.util.Map;
@@ -29,9 +29,7 @@ public interface CredentialsVerifier {
     /**
      * Verifies credentials contained in the given hub.
      *
-     * @param hubBaseUrl the hub base url
-     * @param publicKey  the hub's public key to encrypt messages with
+     * @param participantDid did document of the participant.
      */
-    Result<Map<String, Object>> verifyCredentials(String hubBaseUrl, PublicKeyWrapper publicKey);
-
+    Result<Map<String, Object>> getVerifiedClaims(DidDocument participantDid);
 }

--- a/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/credentials/CredentialsVerifier.java
+++ b/extensions/iam/decentralized-identity/identity-did-spi/src/main/java/org/eclipse/dataspaceconnector/iam/did/spi/credentials/CredentialsVerifier.java
@@ -31,5 +31,5 @@ public interface CredentialsVerifier {
      *
      * @param participantDid did document of the participant.
      */
-    Result<Map<String, Object>> getVerifiedClaims(DidDocument participantDid);
+    Result<Map<String, Object>> verifyCredentials(DidDocument participantDid);
 }


### PR DESCRIPTION
## What this PR changes/adds

Changed CredentialsVerifier to take a DidDocument as an input.

## Why it does that

DidDocument is a good input to verify credentials, as the way to get the credentials (identityHub service) is provided in the DidDocument.
For example, an IdentityHubCredentialVerifier would extract the identityHub URL from the did and query IdentityHub to get the verifiable credentials.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
